### PR TITLE
Fix path in `prof.export_chrome_trace()` from `pretrain_gpt_alcf.py`

### DIFF
--- a/pretrain_gpt_alcf.py
+++ b/pretrain_gpt_alcf.py
@@ -2,6 +2,7 @@
 
 """Pretrain GPT"""
 
+from pathlib import Path
 from mpi4py import MPI
 import os
 from rich import print
@@ -581,9 +582,13 @@ def main():
                 data_post_process=data_post_process
             )
         args = get_args()
-        prof.export_chrome_trace(
-            f"{args.tensorboard_dir}"
-            "/torch-trace-{RANK}-of-{WORLD_SIZE}.json"
+        assert args is not None
+        trace_output = Path(f"{args.tensorboard_dir}").joinpath(
+            f"torch-trace-{RANK}-of-{WORLD_SIZE}.json"
+        )
+        prof.export_chrome_trace(trace_output.as_posix())
+        log.info(
+            f'Saved trace output to: {trace_output.as_posix()}'
         )
     else:
         model = pretrain(


### PR DESCRIPTION
Specifically, fix the location of the output file when using torch profiler via

export TORCH_PROFILER_ENABLED=1
See line 579 [here](https://github.com/argonne-lcf/Megatron-DeepSpeed/commit/7794fc07fe74fcdecc53fa1061e69d2eb8084e6b#diff-52cfc408bada5ae2b6539bda1621ccfd07255629316b7ac4ab08c40bf1dbdc15R579)

Thanks @hatanp for raising this ‼️

\[[to the right branch this time. oops.](https://github.com/microsoft/Megatron-DeepSpeed/pull/390)\]