### PR TITLE
Merge in `tokenizer-tests` branch into `main`

### DIFF
--- a/ALCF/README.md
+++ b/ALCF/README.md
@@ -19,10 +19,10 @@
 
 ## 🏃‍♂️ Running
 
-To launch on Polaris @ [ALCF](https://alcf.anl.gov):
+To launch on {`Polaris`, `Sunspot`} @ [ALCF](https://alcf.anl.gov):
 
 <details closed><summary>⏳ Request an interactive job with <code>qsub -I</code>:</summary>
-    
+
 ```bash
 qsub -A <your-project> -q debug -l select=2 -l walltime=01:00:00,filesystems=eagle:home -I
 ```
@@ -42,14 +42,22 @@ cd Megatron-DeepSpeed
 
 1. 📂 Load `conda` module and activate base environment:
 
-    ```bash
-    module use /soft/modulefiles ; module load conda ; conda activate base
-    ```
+    - **Polaris**:
+
+        ```bash
+        module use /soft/modulefiles ; module load conda ; conda activate base
+        ```
+
+    - **Sunspot**:
+
+        ```bash
+        source ALCF/sunspot-env-2024-04-15-002.sh
+        ```
 
 3. 👻 Create virtual environment _on top of the base `conda`_[^venv]:
 
     ```bash
-    PBS_O_WORKDIR=$(pwd) source ALCF/helpers.sh && setup_venv_from_conda
+    export PBS_O_WORKDIR=$(pwd) && source ALCF/helpers.sh && setup_venv_from_conda
     ```
 
 

--- a/ALCF/sunspot-env-2024-04-15-002.sh
+++ b/ALCF/sunspot-env-2024-04-15-002.sh
@@ -1,0 +1,4 @@
+#!/bin/bash --login
+
+module use /soft/preview-modulefiles/24.086.0
+module load frameworks/2024.04.15.002.lua

--- a/train_aGPT_7B.sh
+++ b/train_aGPT_7B.sh
@@ -7,13 +7,12 @@ cd "${PBS_O_WORKDIR}" || exit
 HOSTNAME=$(hostname)
 if [[ "${HOSTNAME}" == x3* ]]; then
     MACHINE="polaris"
-    # XXX: ¯\_(ツ)_/¯
+    # XXX:
     # - On Polaris, we see that:
     #       - on 1 or 2 nodes, only MICRO_BATCH=1 will fit in memory
     #       - on 8 nodes, MICRO_BATCH=2 will fit in memory
     #       - on 48 nodes, MICRO_BATCH=4 will fit in memory
-    #
-    export nhosts=$(wc -l < "${PBS_NODEFILE}")
+    nhosts=$(wc -l < "${PBS_NODEFILE}")
     if [[ "${nhosts}" == 1 ]]; then
         export MBS=1
     elif [[ "${nhosts}" == 2 ]]; then
@@ -29,6 +28,7 @@ elif [[ "${HOSTNAME}" == x4* ]]; then
     MACHINE="aurora"
 fi
 
+export nhosts
 OUTDIR="${PBS_O_WORKDIR}/pbslogs"
 mkdir -p "${OUTDIR}"
 OUTFILE="${OUTDIR}/${PBS_JOBID}-${NOW}.log"

--- a/train_aGPT_7B.sh
+++ b/train_aGPT_7B.sh
@@ -25,6 +25,6 @@ echo "+---------------------------------------------------------+"
 export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=6000
 echo "${OUTFILE}" >> "${OUTDIR}/latest"
 # export DEBUG=1
-export MICRO_BATCH="${MICRO_BATCH:-${MBS}}"
+# export MICRO_BATCH="${MICRO_BATCH:-${MBS}}"
 export DATA_FILE_LIST="${DATA_FILE_LIST:-${PBS_O_WORKDIR}/ALCF/data-lists/${MACHINE}/dolma_v1_7_file_list.txt}"
 bash "${PBS_O_WORKDIR}/train_llama_alcf.sh" |& tee "${OUTFILE}"

--- a/train_aGPT_7B.sh
+++ b/train_aGPT_7B.sh
@@ -1,5 +1,5 @@
 #!/bin/bash --login
-#
+
 
 NOW="$(date "+%Y-%m-%d-%H%M%S")"
 cd "${PBS_O_WORKDIR}" || exit
@@ -7,30 +7,13 @@ cd "${PBS_O_WORKDIR}" || exit
 HOSTNAME=$(hostname)
 if [[ "${HOSTNAME}" == x3* ]]; then
     MACHINE="polaris"
-    # XXX:
-    # - On Polaris, we see that:
-    #       - on 1 or 2 nodes, only MICRO_BATCH=1 will fit in memory
-    #       - on 8 nodes, MICRO_BATCH=2 will fit in memory
-    #       - on 48 nodes, MICRO_BATCH=4 will fit in memory
-    nhosts=$(wc -l < "${PBS_NODEFILE}")
-    if [[ "${nhosts}" == 1 ]]; then
-        export MBS=1
-    elif [[ "${nhosts}" == 2 ]]; then
-        export MBS=1
-    elif [[ "${nhosts}" -ge 3 ]]; then
-        export MBS=2
-    elif [[ "${nhosts}" -ge 8 ]]; then
-        export MBS=4
-    fi
 elif [[ "${HOSTNAME}" == x1* ]]; then
     MACHINE="sunspot"
 elif [[ "${HOSTNAME}" == x4* ]]; then
     MACHINE="aurora"
 fi
 
-export nhosts
-OUTDIR="${PBS_O_WORKDIR}/pbslogs"
-mkdir -p "${OUTDIR}"
+OUTDIR="${PBS_O_WORKDIR}/pbslogs" && mkdir -p "${OUTDIR}"
 OUTFILE="${OUTDIR}/${PBS_JOBID}-${NOW}.log"
 
 echo "+---------------------------------------------------------+"

--- a/train_llama_alcf.sh
+++ b/train_llama_alcf.sh
@@ -95,6 +95,7 @@ TBDIR="${CKPT_DIR}/tensorboard"
 mkdir -p "${TBDIR}"
 
 data_cache_path="${CKPT_DIR}/${DATA_CACHE_PATH}" && mkdir -p "${data_cache_path}"
+echo "Using data_cache_path: ${data_cache_path}"
 
 
 export DEFAULTS="\
@@ -116,7 +117,6 @@ custom_args=" $@"
     # --log-memory-to-tensorboard \
     # --data-file-list ${DATA_FILE_LIST} \
     # --data-file-list ${DATA_FILE_LIST} \
-    # --data-cache-path ${data_cache_path} \
     # --tokenizer-type Llama2Tokenizer \
     # --tokenizer-model ${TOKENIZER_MODEL} \
 run_cmd="
@@ -143,10 +143,11 @@ run_cmd="
     --pipeline-model-parallel-size ${PP} \
     --num-key-value-heads ${NUM_KV_HEAD} \
     --ffn-hidden-size ${FFN_HIDDEN_SIZE} \
+    --data-cache-path ${data_cache_path} \
+    ${DATA_FLAGS} \
     ${LR_ARGS} \
     ${LLAMA_ARGS} \
     ${TIMING_STR} \
-    ${DATA_FLAGS} \
     ${TOKENIZER_FLAGS} \
     $ds_args \
     ${gpt_args[*]} \


### PR DESCRIPTION
Explicitly, this PR gives the ability to dynamically switch between different tokenizers at runtime[^flash-attn-sunspot].


Supported tokenizers:

- `TOKENIZER_TYPE="llama"` \[**DEFAULT**\] 
    - will use the `Llama2Tokenizer` + whatever `DATA_FILE_LIST` specified
        - if no `DATA_FILE_LIST` specified, will fall back to `ALCF/data-lists/${MACHINE}/dolma_v1_7_file_list.txt`
- `TOKENIZER_TYPE="gpt"`
    - will use the `GPT2BPETokenizer`
        - by default, will use the `BookCorpusDataset` with the `gpt2-merges` and `vocab` file(s).

[^flash-attn-sunspot]: This is in an effort to better understand the behavior of `flash-attn` on Sunspot. 
    For additional details see: [📸 `flash-attn` on Sunspot](https://samforeman.me/qmd/flash-attn-sunspot/)