### PR TITLE
Concat datasets that belongs the same corpus

### DIFF
--- a/ALCF/test_blendable_dataset.py
+++ b/ALCF/test_blendable_dataset.py
@@ -6,25 +6,32 @@ from megatron.global_vars import set_args, set_global_variables, get_args
 from megatron.arguments import parse_args 
 from megatron.initialize import initialize_megatron
 from megatron.data.data_samplers import build_pretraining_data_loader
-
+import time
 from megatron.core import mpu
 comm = MPI.COMM_WORLD
+
+import datetime
+def print_rank_0(msg):
+    if comm.rank==0:
+        print(f" [INFO][{datetime.datetime.now()}] {msg}", flush=True)
+        
+
 initialize_megatron(allow_no_cuda=True)
 args = get_args()
 
 data_file_list = args.data_file_list
-if comm.rank==0:
-    print(f"Reading data from {args.data_file_list}")
+print_rank_0(f"Reading data from {args.data_file_list}")
 files = []
 weights = []
 flist = []
 with open(data_file_list, 'r') as fin:
     for f in fin.readlines():
-        w, fname = f.split()
+        w, fname, c = f.split()
         weights.append(float(w))
         flist.append(fname)
         files.append(float(w))
         files.append(fname)
+        files.append(c)
 splits_string="100,0,0"
 
 weights = np.array(weights)
@@ -32,10 +39,9 @@ weights = weights/np.sum(weights)
 
 num_samples = args.global_batch_size*args.train_iters
 num_datasets = len(weights)
-if comm.rank==0:
-    print(f"Number of datasets: {num_datasets}")
-    print(f"Global batch size: {args.global_batch_size}")
-    print(f"Training iterations: {args.train_iters}")
+print_rank_0(f"Number of datasets: {num_datasets}")
+print_rank_0(f"Global batch size: {args.global_batch_size}")
+print_rank_0(f"Training iterations: {args.train_iters}")
 train_valid_test_num_samples = [num_samples, 0, 0]
 seed=args.seed
 data_impl = args.data_impl
@@ -44,40 +50,51 @@ seq_length = args.seq_length
 splits_string = "1,0,0"
 
 # Build datasets
+start_build_dataset = time.time()
+print_rank_0(f"Starting to build the blendable dataset")
 train_ds, valid_ds, test_ds = build_train_valid_test_datasets(files, data_impl, splits_string,
                             train_valid_test_num_samples,
                             seq_length, seed, skip_warmup, data_cache_path=args.data_cache_path)
 
-dataset_idx = [train_ds.dataset_index[i] for i in range(num_samples)]
-ratio_select=np.zeros(num_datasets)
-#for i in range(num_datasets):
-#    ratio_select[i] = np.sum([i==d for d in dataset_idx])/num_samples
-if comm.rank ==0:
-    print(f"Total number of samples: {len(train_ds)}")
-    print(f"Weights set: {weights[:min(8, num_datasets)]}")
 
-for e in range(min(100, args.train_iters)):
-    ratio_select=np.zeros(num_datasets)
-    for i in range(num_datasets):
-        ratio_select[i] = np.sum([i==d for d in dataset_idx[e*args.global_batch_size:(e+1)*args.global_batch_size]])/args.global_batch_size
-    if comm.rank==0:
-        print(f"iter-{e}: {ratio_select[:min(8, num_datasets)]}")
+end_build_dataset = time.time()
+print_rank_0(f"Finished building the blendable dataset in {end_build_dataset - start_build_dataset} second")
+print_rank_0(f"Total number of samples: {len(train_ds)}")
+print_rank_0(f"Weights set: {weights[:min(8, num_datasets)]}")
 
-
-print("First 10 samples")
-for i in range(10):
-    if comm.rank==0:
-        print(f"Sample: {i} \t dataset_idx: {train_ds.dataset_index[i]}, sample_idx: {train_ds.dataset_sample_index[i]}")
-
-#### Build data loaders
+start_build_dataloader = time.time()
+print_rank_0(f"Starting to build the data loader")
 rank_in_parallel_group = mpu.get_sequence_parallel_rank()
 train_dataloader = build_pretraining_data_loader(
     train_ds, args.consumed_train_samples)
 valid_dataloader = build_pretraining_data_loader(
         valid_ds, args.consumed_valid_samples)
 test_dataloader = build_pretraining_data_loader(test_ds, 0)
+end_build_dataloader = time.time()
+print_rank_0(f"Finished building the data loader in {end_build_dataloader - start_build_dataloader} second")
 
-
-# Run through all the batches in data loader
+print_rank_0(f"Starting loading the data")
+start_loading_time = time.time()
+NUM_ITEMS=100
+n=0
 for i in train_dataloader:
-    print(i)
+    print(f"[{comm.rank}] DATA {i}")
+    n+=1
+    if (n%NUM_ITEMS==0):
+        print_rank_0(f"Loaded {n} batches in {time.time() - start_loading_time}")
+    if n>=5000:
+        break
+end_loading_time = time.time()
+print_rank_0(f"Finished loading the data ({n} batches) in {end_loading_time - start_loading_time}")
+
+
+
+dataset_idx = [train_ds.dataset_index[i] for i in range(num_samples)]
+ratio_select=np.zeros(num_datasets)
+
+for e in range(min(100, args.train_iters)):
+    ratio_select=np.zeros(num_datasets)
+    for i in range(num_datasets):
+        ratio_select[i] = np.sum([i==d for d in dataset_idx[e*args.global_batch_size:(e+1)*args.global_batch_size]])/args.global_batch_size
+    print_rank_0(f"iter-{e}: {ratio_select[:min(8, num_datasets)]}")
+

--- a/megatron/data/blendable_dataset.py
+++ b/megatron/data/blendable_dataset.py
@@ -91,6 +91,7 @@ class BlendableDataset(torch.utils.data.Dataset):
                 exit()
 
             if cache_hit:
+                print_rank_0(f"> index map files exists already, rank 0 will read them and broadcast to all the rank")
                 print_rank_0(f'> loading blendable dataset index: {index_path}')
                 self.dataset_index = np.load(index_path, allow_pickle=True, mmap_mode='r')
                 assert self.dataset_index.size == self.size

--- a/megatron/data/blendable_dataset.py
+++ b/megatron/data/blendable_dataset.py
@@ -12,7 +12,7 @@ import torch
 from deepspeed.accelerator import get_accelerator
 from megatron import print_rank_0, print_flush
 from megatron.core import mpu
-from mpi4py import MPI
+
 class BlendableDataset(torch.utils.data.Dataset):
 
 

--- a/megatron/data/blendable_dataset.py
+++ b/megatron/data/blendable_dataset.py
@@ -122,19 +122,4 @@ class BlendableDataset(torch.utils.data.Dataset):
         return {
             "dataset_idx" : dataset_idx,
             **self.datasets[dataset_idx][sample_idx],
-        }
-
-class DistributedBlendableDataset(BlendableDataset):
-    def __getitem__(self, idx):
-        dataset_idx = self.dataset_index[idx]
-        sample_idx = self.dataset_sample_index[idx]
-        if (self.datasets[dataset_idx].build):
-            dataset = self.datasets[dataset_idx].dataset
-        else:
-            print_flush(f" First time reading samples from {self.datasets[dataset_idx].prefix}. Building the dataset now.")
-            dataset = self.datasets[dataset_idx].Build()
-        return {
-            "dataset_idx" : dataset_idx,
-            **dataset[sample_idx],
-        }
-            
+        }            

--- a/megatron/data/blendable_dataset.py
+++ b/megatron/data/blendable_dataset.py
@@ -78,7 +78,7 @@ class BlendableDataset(torch.utils.data.Dataset):
                     print('write access to.')
                     cache_success = False
 
-
+            
             counts = get_accelerator().LongTensor([cache_success])
             torch.distributed.all_reduce(counts, group=mpu.get_data_parallel_group())
             torch.distributed.all_reduce(counts, group=mpu.get_pipeline_model_parallel_group())

--- a/megatron/data/dataset_utils.py
+++ b/megatron/data/dataset_utils.py
@@ -40,6 +40,18 @@ DSET_TYPE_T5  = 't5'
 
 DSET_TYPES = [DSET_TYPE_BERT, DSET_TYPE_ICT, DSET_TYPE_T5]
 
+def get_datasets_corpuses_weights_and_num_samples(data_prefix, train_valid_test_num_samples):
+    assert len(data_prefix) % 3 == 0
+    num_datasets = len(data_prefix) // 3
+    data_new_prefix = []
+    corpuses = []
+    for i in range(num_datasets):
+        data_new_prefix += [data_prefix[3*i], data_prefix[3*i+1]]
+        corpuses.append(data_prefix[3*i+2])
+    prefixes, weights, datasets_train_valid_test_num_samples = \
+        get_datasets_weights_and_num_samples(data_prefix,
+                                             train_valid_test_num_samples)
+    return prefixes, corpuses, weights, datasets_train_valid_test_num_samples
 
 def get_datasets_weights_and_num_samples(data_prefix,
                                          train_valid_test_num_samples):

--- a/pretrain_gpt_alcf.py
+++ b/pretrain_gpt_alcf.py
@@ -498,13 +498,16 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
         '> building train, validation, and test datasets for GPT ...'
     )
     files = []
+    # making it the default input method
+    assert(agrs.data_file_list is not None)
     if args.data_file_list is not None:
         log.info(f"Reading datasets from {args.data_file_list}")
         with open(args.data_file_list, 'r') as flist:
             for f in flist.readlines():
-                w, fname = f.split()
+                w, fname, c = f.split()
                 files.append(float(w))
                 files.append(fname)
+                files.append(c)
     elif len(args.data_path) == 1 and os.path.isdir(args.data_path[0]):
         path = args.data_path[0] + "/"
         for f in os.listdir(path):
@@ -521,8 +524,7 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
         train_valid_test_num_samples=train_val_test_num_samples,
         seq_length=args.seq_length,
         seed=args.seed,
-        skip_warmup=True,
-        # skip_warmup=(not args.mmap_warmup),
+        skip_warmup=(not args.mmap_warmup),
         train_data_prefix=args.train_data_path,
         valid_data_prefix=args.valid_data_path,
         test_data_prefix=args.test_data_path,


### PR DESCRIPTION
I found that building_indices is very expensive if we have large amount of dataset files. It is almost proportional to the number of files. For loading 2T tokens with (4k seq length), it will take about 1s for 1 file, where as 2000s for 2419 files (dolma v1.7). 

The trick is to reduce the number of datasets in the BlendableDataset construction. What I did was concat all the datasets that belong to the same corpus into a single dataset, and then build the BlendableDataset on top of that. I have solved some subtle issues on the way to achieve this. 

Overall, with the new version of the data loader, it achieves 20x speed up on the data loader for loading 2000,0000,000,000 tokens (dolma v1.7)

The experiments were done on Sunspot from 1 nodes to 16 nodes. We see consistent performance improvement up to 20x.

My version 1 gets the green bars down but not the yellow bars
https://github.com/argonne-lcf/Megatron-DeepSpeed/tree/distributed_loading
My version 2 gets the yellow bars down by 100x by grouping all the datasets belong to the same corpus together
https://github.com/argonne-lcf/Megatron-DeepSpeed/tree/distributed_loading_v2

The performance evaluation is shown here: 
[md_distributed_dataloader.pdf](https://github.com/user-attachments/files/15517826/md_distributed_dataloader.pdf)
