### PR TITLE
Hide data-specific logs behind `DEBUG` logging level

### DIFF
--- a/ALCF/requirements/requirements.txt
+++ b/ALCF/requirements/requirements.txt
@@ -15,6 +15,4 @@ six
 numpy<2
 schedulefree
 packaging>=20.0
-pydftracer
 wandb
-# git+https://github.com/saforem2/ezpz@main

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1291,6 +1291,8 @@ def _add_data_args(parser):
     group.add_argument('--data-file-list', type=str, default=None,
                        help='The file with the list of dataset and weights')
     
+    group.add_argument('--shuffle-sample', action='store_true', help="Whether to shuffle the samples within in the dataset files")
+
     group.add_argument('--split', type=str, default='969, 30, 1',
                        help='Comma-separated list of proportions for training,'
                        ' validation, and test split. For example the split '

--- a/megatron/data/blendable_dataset.py
+++ b/megatron/data/blendable_dataset.py
@@ -6,14 +6,20 @@ import hashlib
 import os
 import time
 
+import logging
 import numpy as np
 import torch
 
 from deepspeed.accelerator import get_accelerator
-from megatron import print_rank_0
+# from megatron import print_rank_0
 from megatron.core import mpu
 from megatron.utils import Profile, PerfTrace
 from mpi4py import MPI
+
+from megatron.utils import get_logger
+
+log = get_logger(__name__, rank_zero_only=True)
+
 dlp = Profile("DATASET")
 class BlendableDataset(torch.utils.data.Dataset):
     @dlp.log
@@ -43,7 +49,7 @@ class BlendableDataset(torch.utils.data.Dataset):
             helpers.build_blending_indices(dataset_index, dataset_sample_index,
                                            weights, num_datasets, self.size,
                                            torch.distributed.get_rank() == 0)
-            print_rank_0('> elapsed time for building blendable dataset indices: '
+            log.info('> elapsed time for building blendable dataset indices: '
                          '{:.2f} (sec)'.format(time.time() - start_time))
             return dataset_index, dataset_sample_index
 
@@ -68,7 +74,7 @@ class BlendableDataset(torch.utils.data.Dataset):
                       ' dataset, building indices on rank 0 ...', flush=True)
                 dataset_index, dataset_sample_index = _build_indices()
                 try:
-                    print_rank_0(" > saving index map files")
+                    log.info(" > saving index map files")
                     start_time = time.time()
                     os.makedirs(os.path.dirname(index_path), exist_ok=True)
                     with open(desc_path, 'wt') as fd:
@@ -76,7 +82,7 @@ class BlendableDataset(torch.utils.data.Dataset):
                         np.save(index_path, dataset_index, allow_pickle=True)
                         np.save(sample_index_path, dataset_sample_index,
                                 allow_pickle=True)
-                    print_rank_0(f" > finished saving index map files in {time.time() - start_time} seconds")
+                    log.info(f" > finished saving index map files in {time.time() - start_time} seconds")
                 except OSError:
                     print(f'There was an error trying to create the data cache directory ({data_cache_path})')
                     print('or a file in it. This is set with the --data-cache-path argument. Please')
@@ -93,7 +99,7 @@ class BlendableDataset(torch.utils.data.Dataset):
                     torch.distributed.get_world_size() //
                     torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group()) //
                     torch.distributed.get_world_size(group=mpu.get_sequence_parallel_group())):
-                print_rank_0("Data index creation unsuccessful, exiting.")
+                log.info("Data index creation unsuccessful, exiting.")
                 exit()
             '''
             torch.distributed.barrier(group=mpu.get_data_parallel_group())
@@ -101,13 +107,13 @@ class BlendableDataset(torch.utils.data.Dataset):
             torch.distributed.barrier(group=mpu.get_data_parallel_group())
             
             start_time = time.time()
-            print_rank_0(f'> loading blendable dataset index: {index_path}')
+            log.info(f'> loading blendable dataset index: {index_path}')
             self.dataset_index = np.load(index_path, allow_pickle=True, mmap_mode='r')
             assert self.dataset_index.size == self.size
-            print_rank_0(f'> loading blendable dataset sample index: {sample_index_path}')
+            log.info(f'> loading blendable dataset sample index: {sample_index_path}')
             self.dataset_sample_index = np.load(sample_index_path, allow_pickle=True, mmap_mode='r')
             assert self.dataset_sample_index.size == self.size
-            print_rank_0(f'> finished loading in {time.time() - start_time} seconds')            
+            log.info(f'> finished loading in {time.time() - start_time} seconds')            
         else:
             self.dataset_index, self.dataset_sample_index = _build_indices()
 
@@ -119,7 +125,7 @@ class BlendableDataset(torch.utils.data.Dataset):
             raise RuntimeError('BlendedDataset size is improperly bounded')
         except IndexError:
             pass
-        print_rank_0('> size of blendable dataset: '
+        log.info('> size of blendable dataset: '
                      '{} samples'.format(self.size))
 
 

--- a/megatron/data/gpt_dataset.py
+++ b/megatron/data/gpt_dataset.py
@@ -9,67 +9,96 @@ import time
 import numpy as np
 import torch
 from deepspeed.accelerator import get_accelerator
-from megatron import print_rank_0, is_rank_0, get_args
+from megatron import is_rank_0, get_args
 from megatron.core import mpu
-from megatron.data import helpers
+from megatron.data import helpers  # type:ignore
 from megatron.data.blendable_dataset import BlendableDataset
-from megatron.data.dataset_utils import get_datasets_weights_and_num_samples, get_datasets_corpuses_weights_and_num_samples
+from megatron.data.dataset_utils import (
+    get_datasets_weights_and_num_samples,
+    get_datasets_corpuses_weights_and_num_samples,
+)
 from megatron.data.dataset_utils import get_train_valid_test_split_
 from megatron.data.indexed_dataset import make_dataset as make_indexed_dataset
 
-from megatron.utils import PerfTrace, Profile
+from megatron.utils import PerfTrace, Profile, get_logger
 from mpi4py import MPI
 
 dlp = Profile("DATASET")
 
+log = get_logger(__name__, rank_zero_only=True)
+
+
 @dlp.log
-def build_train_valid_test_datasets(data_prefix, data_impl, splits_string,
-                                    train_valid_test_num_samples,
-                                    seq_length, seed, skip_warmup,
-                                    train_data_prefix=None,
-                                    valid_data_prefix=None,
-                                    test_data_prefix=None,
-                                    return_doc_ids=False, *,
-                                    data_cache_path=None):
+def build_train_valid_test_datasets(
+    data_prefix,
+    data_impl,
+    splits_string,
+    train_valid_test_num_samples,
+    seq_length,
+    seed,
+    skip_warmup,
+    train_data_prefix=None,
+    valid_data_prefix=None,
+    test_data_prefix=None,
+    return_doc_ids=False,
+    *,
+    data_cache_path=None,
+):
     """Build train, valid, and test datasets."""
 
     if data_prefix:
-        print_rank_0("Single data path provided for train, valid & test")
+        log.debug("Single data path provided for train, valid & test")
 
         # Single dataset.
         if len(data_prefix) == 1:
-            return _build_train_valid_test_datasets(data_prefix[0],
-                                                    data_impl, splits_string,
-                                                    train_valid_test_num_samples,
-                                                    seq_length, seed, skip_warmup,
-                                                    data_cache_path=data_cache_path)
+            return _build_train_valid_test_datasets(
+                data_prefix[0],
+                data_impl,
+                splits_string,
+                train_valid_test_num_samples,
+                seq_length,
+                seed,
+                skip_warmup,
+                data_cache_path=data_cache_path,
+            )
 
         # Blending dataset.
         # Parse the values.
-        output = get_datasets_corpuses_weights_and_num_samples(data_prefix,
-                                                      train_valid_test_num_samples)
+        output = get_datasets_corpuses_weights_and_num_samples(
+            data_prefix, train_valid_test_num_samples
+        )
         prefixes, corpuses, weights, datasets_train_valid_test_num_samples = output
         corpus_list = sorted(set(corpuses))
         train_num_samples, valid_num_samples, test_num_samples = map(
-            sum,
-            zip(*datasets_train_valid_test_num_samples)
+            sum, zip(*datasets_train_valid_test_num_samples)
         )
 
         class DatasetBuilder:
-            ''' 
+            """
             This is for building individual dataset from each dataset file
-            '''
+            """
+
             @dlp.log
-            def __init__(self, prefix, corpus, data_impl, splits_string,
-                         num_samples, seq_length, seed, skip_warmup,
-                         return_doc_ids,
-                         data_cache_path=data_cache_path, name='train'):
+            def __init__(
+                self,
+                prefix,
+                corpus,
+                data_impl,
+                splits_string,
+                num_samples,
+                seq_length,
+                seed,
+                skip_warmup,
+                return_doc_ids,
+                data_cache_path=data_cache_path,
+                name="train",
+            ):
                 self.prefix = prefix
                 self.data_impl = data_impl
                 self.splits_string = splits_string
-                if name == 'train':
+                if name == "train":
                     self.num_samples = num_samples[0]
-                elif name == 'valid':
+                elif name == "valid":
                     self.num_samples = num_samples[1]
                 else:
                     self.num_samples = num_samples[2]
@@ -84,11 +113,21 @@ def build_train_valid_test_datasets(data_prefix, data_impl, splits_string,
                 self.desc = prefix + f"{self.num_samples}" + f"{seq_length}" + f"{seed}"
                 self.build = False
                 self.corpus = corpus
+
             @dlp.log
             def Build(self):
-                self.dataset = _build_train_valid_test_datasets_single(self.prefix, self.data_impl, self.splits_string,
-                    self.num_samples_train_valid_test, self.seq_length, self.seed, self.skip_warmup, self.name, self.return_doc_ids, 
-                    data_cache_path=self.data_cache_path)
+                self.dataset = _build_train_valid_test_datasets_single(
+                    self.prefix,
+                    self.data_impl,
+                    self.splits_string,
+                    self.num_samples_train_valid_test,
+                    self.seq_length,
+                    self.seed,
+                    self.skip_warmup,
+                    self.name,
+                    self.return_doc_ids,
+                    data_cache_path=self.data_cache_path,
+                )
                 self.build = True
                 return self.dataset
 
@@ -98,21 +137,27 @@ def build_train_valid_test_datasets(data_prefix, data_impl, splits_string,
                 self.dataset_builders = dataset_builders
                 self.num_datasets = len(dataset_builders)
                 self.num_samples = np.sum([d.num_samples for d in dataset_builders])
-                self.indices=np.zeros((self.num_samples, 2), dtype=np.uint64)
-                self.desc="ConcatDataset:"
-                m = 0
+                self.indices = np.zeros((self.num_samples, 2), dtype=np.uint64)
+                self.desc = "ConcatDataset:"
+                # m = 0
                 num_samples_list = np.array([d.num_samples for d in dataset_builders])
                 self.num_samples = np.sum(num_samples_list)
+
                 def _build_indices():
                     start_time = time.time()
                     dataset_index = np.zeros(self.num_samples, dtype=np.int64)
                     dataset_sample_index = np.zeros(self.num_samples, dtype=np.int64)
-                    helpers.build_concat_indices(dataset_index, dataset_sample_index,
-                                                 num_samples_list, 
-                                                 self.num_datasets, 
-                                                 torch.distributed.get_rank()==0)
-                    print_rank_0('> elapsed time for building concat dataset indices: '
-                                 '{:.2f} (sec)'.format(time.time() - start_time))
+                    helpers.build_concat_indices(
+                        dataset_index,
+                        dataset_sample_index,
+                        num_samples_list,
+                        self.num_datasets,
+                        torch.distributed.get_rank() == 0,
+                    )
+                    log.debug(
+                        "> elapsed time for building concat dataset indices: "
+                        "{:.2f} (sec)".format(time.time() - start_time)
+                    )
                     return dataset_index, dataset_sample_index
 
                 self.dataset_index, self.dataset_sample_index = _build_indices()
@@ -122,7 +167,12 @@ def build_train_valid_test_datasets(data_prefix, data_impl, splits_string,
                 for i in range(self.num_datasets):
                     self.desc += dataset_builders[i].prefix + ","
 
-                self.desc += f"-{self.num_samples}" + f"-{dataset_builders[0].seq_length}" + f"{dataset_builders[0].seed}"
+                self.desc += (
+                    f"-{self.num_samples}"
+                    + f"-{dataset_builders[0].seq_length}"
+                    + f"{dataset_builders[0].seed}"
+                )
+
             def __len__(self):
                 return self.num_samples
 
@@ -135,227 +185,340 @@ def build_train_valid_test_datasets(data_prefix, data_impl, splits_string,
                     return self.dataset_builders[i].dataset[j]
                 else:
                     return self.dataset_builders[i].Build()[j]
-            
 
-        # Predetermine whether need to build the specific dataset or not. 
+        # Predetermine whether need to build the specific dataset or not.
         start_time = time.time()
-        print_rank_0(" >>> Started building datasets in distributed way ... ")
+        log.debug(" >>> Started building datasets in distributed way ... ")
 
         a, b, c = [int(d) for d in splits_string.split(",")]
-        
+
         train_datasets = []
         valid_datasets = []
         test_datasets = []
         # Build individual datasets.
 
         @dlp.log
-        def build_corpus_datasets(dataset_type='train'):
+        def build_corpus_datasets(dataset_type="train"):
             start_time = time.time()
-            print_rank_0(f" >>> Building {dataset_type} corpus datasets ...")
+            log.debug(f" >>> Building {dataset_type} corpus datasets ...")
             datasets = []
             corpus_builders = {}
             corpus_weights = {}
             for c in corpus_list:
                 corpus_builders[c] = []
                 corpus_weights[c] = 0.0
-            dataset_builders = [DatasetBuilder(prefixes[i], corpuses[i], data_impl, splits_string,
-                                               datasets_train_valid_test_num_samples[i],
-                                               seq_length, seed, skip_warmup,
-                                               return_doc_ids,data_cache_path, dataset_type) for i in  range(len(weights))]
-            for i in range(torch.distributed.get_rank()//mpu.get_tensor_model_parallel_world_size(), len(weights),  torch.distributed.get_world_size()//mpu.get_tensor_model_parallel_world_size()):
+            dataset_builders = [
+                DatasetBuilder(
+                    prefixes[i],
+                    corpuses[i],
+                    data_impl,
+                    splits_string,
+                    datasets_train_valid_test_num_samples[i],
+                    seq_length,
+                    seed,
+                    skip_warmup,
+                    return_doc_ids,
+                    data_cache_path,
+                    dataset_type,
+                )
+                for i in range(len(weights))
+            ]
+            for i in range(
+                torch.distributed.get_rank()
+                // mpu.get_tensor_model_parallel_world_size(),
+                len(weights),
+                torch.distributed.get_world_size()
+                // mpu.get_tensor_model_parallel_world_size(),
+            ):
                 dataset_builders[i].Build()
-            print_rank_0(f" >>> Finished building individual datasets in {time.time() - start_time} seconds")
+            log.debug(
+                f" >>> Finished building individual datasets in {time.time() - start_time} seconds"
+            )
             start_concating_time = time.time()
             for i, d in zip(range(len(weights)), dataset_builders):
                 corpus_builders[d.corpus].append(d)
                 corpus_weights[d.corpus] += weights[i]
             total = 0
-            print_rank_0(" > number of samples for each corpus ")
-            corpus_weights_achieved={}
+            log.debug(" > number of samples for each corpus ")
+            corpus_weights_achieved = {}
             for c in corpus_list:
                 datasets.append(BuildConcatDataset(corpus_builders[c]))
                 total += datasets[-1].num_samples
-                corpus_weights_achieved[c] =  float(datasets[-1].num_samples)/train_num_samples                
-                print_rank_0(f"    {c}: {datasets[-1].num_samples} w={corpus_weights_achieved[c]} (expected: {corpus_weights[c]})")
-            
-            print_rank_0(f" > total number of samples: {total}")
-            print_rank_0(f" >>> Finished concatenating datasets in {time.time() - start_concating_time} seconds")
-            print_rank_0(f" >>> Finished building {dataset_type} corpus datasets in {time.time() - start_time} seconds")
+                corpus_weights_achieved[c] = (
+                    float(datasets[-1].num_samples) / train_num_samples
+                )
+                log.debug(
+                    f"    {c}: {datasets[-1].num_samples} w={corpus_weights_achieved[c]} (expected: {corpus_weights[c]})"
+                )
+
+            log.debug(f" > total number of samples: {total}")
+            log.debug(
+                f" >>> Finished concatenating datasets in {time.time() - start_concating_time} seconds"
+            )
+            log.debug(
+                f" >>> Finished building {dataset_type} corpus datasets in {time.time() - start_time} seconds"
+            )
             return datasets, [corpus_weights_achieved[c] for c in corpus_list]
 
+        train_weights = None
         if a > 0:
-            train_datasets, train_weights = build_corpus_datasets('train')
-
+            train_datasets, train_weights = build_corpus_datasets("train")
+        valid_weights = None
         if b > 0:
-            valid_datasets, valid_weights = build_corpus_datasets('valid')
-            
-        if c > 0:            
-            test_datasets, test_weights = build_corpus_datasets('test')
+            valid_datasets, valid_weights = build_corpus_datasets("valid")
+        test_weights = None
+        if c > 0:
+            test_datasets, test_weights = build_corpus_datasets("test")
 
         # This barrier is critical to make sure that all the datasets are built once
         # and the metadata were written to the cache folder before other ranks touch them
-        print_rank_0(f" >>> Rank 0 - finished building datasets in {time.time() - start_time} seconds")
+        log.debug(
+            f" >>> Rank 0 - finished building datasets in {time.time() - start_time} seconds"
+        )
         torch.distributed.barrier(group=mpu.get_data_parallel_group())
         torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
         torch.distributed.barrier(group=mpu.get_data_parallel_group())
-        print_rank_0(f" >>> Finished building datasets (all ranks) in distributed way in {time.time() - start_time} seconds")
-        print_rank_0(f" >>> Starting to build BlendableDataset")
+        log.debug(
+            f" >>> Finished building datasets (all ranks) in distributed way in {time.time() - start_time} seconds"
+        )
+        log.debug(" >>> Starting to build BlendableDataset")
         # Blend.
         start_time = time.time()
         blending_train_dataset = None
-        if train_datasets:
-            blending_train_dataset = BlendableDataset(train_datasets, train_weights, train_num_samples,
-                                                      data_cache_path=data_cache_path)
+        if train_datasets and train_weights:
+            blending_train_dataset = BlendableDataset(
+                train_datasets,
+                train_weights,
+                train_num_samples,
+                data_cache_path=data_cache_path,
+            )
         blending_valid_dataset = None
-        if valid_datasets:
-            blending_valid_dataset = BlendableDataset(valid_datasets, valid_weights, valid_num_samples,
-                                                      data_cache_path=data_cache_path)
+        if valid_datasets and valid_weights:
+            blending_valid_dataset = BlendableDataset(
+                valid_datasets,
+                valid_weights,
+                valid_num_samples,
+                data_cache_path=data_cache_path,
+            )
         blending_test_dataset = None
-        if test_datasets:
-            blending_test_dataset = BlendableDataset(test_datasets, test_weights, test_num_samples,
-                                                     data_cache_path=data_cache_path)
+        if test_datasets and test_weights:
+            blending_test_dataset = BlendableDataset(
+                test_datasets,
+                test_weights,
+                test_num_samples,
+                data_cache_path=data_cache_path,
+            )
         end_time = time.time()
-        print_rank_0(f" >>> Finished building BlendableDataset in {end_time - start_time} seconds")
-        return (blending_train_dataset, blending_valid_dataset,
-                blending_test_dataset)
+        log.debug(
+            f" >>> Finished building BlendableDataset in {end_time - start_time} seconds"
+        )
+        return (blending_train_dataset, blending_valid_dataset, blending_test_dataset)
 
     else:
-        print_rank_0("Separate data paths provided for train, valid & test. Split string will be ignored.")
+        log.debug(
+            "Separate data paths provided for train, valid & test. Split string will be ignored."
+        )
 
         train_dataset, valid_dataset, test_dataset = None, None, None
         # Single dataset.
         if train_data_prefix is not None:
-            train_dataset = build_dataset("train", train_data_prefix, data_impl,
-                                          splits_string,
-                                          train_valid_test_num_samples[0],
-                                          seq_length, seed, skip_warmup,
-                                          data_cache_path=data_cache_path)
+            train_dataset = build_dataset(
+                "train",
+                train_data_prefix,
+                data_impl,
+                splits_string,
+                train_valid_test_num_samples[0],
+                seq_length,
+                seed,
+                skip_warmup,
+                data_cache_path=data_cache_path,
+            )
 
         if valid_data_prefix is not None:
-            valid_dataset = build_dataset("valid", valid_data_prefix, data_impl,
-                                          splits_string,
-                                          train_valid_test_num_samples[1],
-                                          seq_length, seed, False,
-                                          data_cache_path=data_cache_path)
-
+            valid_dataset = build_dataset(
+                "valid",
+                valid_data_prefix,
+                data_impl,
+                splits_string,
+                train_valid_test_num_samples[1],
+                seq_length,
+                seed,
+                False,
+                data_cache_path=data_cache_path,
+            )
 
         if test_data_prefix is not None:
-            test_dataset = build_dataset("test", test_data_prefix, data_impl,
-                                         splits_string,
-                                         train_valid_test_num_samples[2],
-                                         seq_length, seed, False,
-                                         data_cache_path=data_cache_path)
+            test_dataset = build_dataset(
+                "test",
+                test_data_prefix,
+                data_impl,
+                splits_string,
+                train_valid_test_num_samples[2],
+                seq_length,
+                seed,
+                False,
+                data_cache_path=data_cache_path,
+            )
 
         return (train_dataset, valid_dataset, test_dataset)
 
+
 @dlp.log
-def _build_train_valid_test_datasets(data_prefix, data_impl, splits_string,
-                                     train_valid_test_num_samples,
-                                     seq_length, seed, skip_warmup,
-                                     return_doc_ids=False, *,
-                                     data_cache_path=None):
+def _build_train_valid_test_datasets(
+    data_prefix,
+    data_impl,
+    splits_string,
+    train_valid_test_num_samples,
+    seq_length,
+    seed,
+    skip_warmup,
+    return_doc_ids=False,
+    *,
+    data_cache_path=None,
+):
     """Build train, valid, and test datasets."""
 
     # Indexed dataset.
-    indexed_dataset = get_indexed_dataset_(data_prefix,
-                                           data_impl,
-                                           skip_warmup)
+    indexed_dataset = get_indexed_dataset_(data_prefix, data_impl, skip_warmup)
 
     total_num_of_documents = indexed_dataset.sizes.shape[0]
     splits = get_train_valid_test_split_(splits_string, total_num_of_documents)
 
     # Print stats about the splits.
-    print_rank_0(' > dataset split:')
+    log.debug(" > dataset split:")
 
     def print_split_stats(name, index):
-        print_rank_0('    {}:'.format(name))
-        print_rank_0('     document indices in [{}, {}) total of {} '
-                     'documents'.format(splits[index], splits[index + 1],
-                                        splits[index + 1] - splits[index]))
-    print_split_stats('train', 0)
-    print_split_stats('validation', 1)
-    print_split_stats('test', 2)
+        log.debug("    {}:".format(name))
+        log.debug(
+            "     document indices in [{}, {}) total of {} " "documents".format(
+                splits[index], splits[index + 1], splits[index + 1] - splits[index]
+            )
+        )
+
+    print_split_stats("train", 0)
+    print_split_stats("validation", 1)
+    print_split_stats("test", 2)
 
     def build_dataset(index, name):
         dataset = None
         if splits[index + 1] > splits[index]:
-            documents = np.arange(start=splits[index], stop=splits[index + 1],
-                                  step=1, dtype=np.int32)
-            dataset = GPTDataset(name, data_prefix, documents, indexed_dataset,
-                                 splits_string,
-                                 train_valid_test_num_samples[index],
-                                 seq_length, seed,
-                                 return_doc_ids,
-                                 data_cache_path=data_cache_path)
+            documents = np.arange(
+                start=splits[index], stop=splits[index + 1], step=1, dtype=np.int32
+            )
+            dataset = GPTDataset(
+                name,
+                data_prefix,
+                documents,
+                indexed_dataset,
+                splits_string,
+                train_valid_test_num_samples[index],
+                seq_length,
+                seed,
+                return_doc_ids,
+                data_cache_path=data_cache_path,
+            )
         return dataset
 
-    train_dataset = build_dataset(0, 'train')
-    valid_dataset = build_dataset(1, 'valid')
-    test_dataset = build_dataset(2, 'test')
+    train_dataset = build_dataset(0, "train")
+    valid_dataset = build_dataset(1, "valid")
+    test_dataset = build_dataset(2, "test")
 
     return (train_dataset, valid_dataset, test_dataset)
 
+
 @dlp.log
-def _build_train_valid_test_datasets_single(data_prefix, data_impl, splits_string,
-                            train_valid_test_num_samples,
-                            seq_length, seed, skip_warmup, name, 
-                            return_doc_ids=False, *,
-                            data_cache_path=None):
+def _build_train_valid_test_datasets_single(
+    data_prefix,
+    data_impl,
+    splits_string,
+    train_valid_test_num_samples,
+    seq_length,
+    seed,
+    skip_warmup,
+    name,
+    return_doc_ids=False,
+    *,
+    data_cache_path=None,
+):
     """Build train, valid, and test datasets."""
 
     # Each rank print out information
-    print_rank_0(f" >> building dataset for {data_prefix}")
+    log.debug(f" >> building dataset for {data_prefix}")
     # Indexed dataset.
-    indexed_dataset = get_indexed_dataset_(data_prefix,
-                                           data_impl,
-                                           skip_warmup)
+    indexed_dataset = get_indexed_dataset_(data_prefix, data_impl, skip_warmup)
 
     total_num_of_documents = indexed_dataset.sizes.shape[0]
     splits = get_train_valid_test_split_(splits_string, total_num_of_documents)
 
     # Print stats about the splits.
-    print_rank_0(' > dataset split:')
+    log.debug(" > dataset split:")
 
     def print_split_stats(name, index):
-        print_rank_0('    {}:'.format(name))
-        print_rank_0('     document indices in [{}, {}) total of {} '
-                     'documents'.format(splits[index], splits[index + 1],
-                                        splits[index + 1] - splits[index]))
-    print_split_stats('train', 0)
-    print_split_stats('validation', 1)
-    print_split_stats('test', 2)
+        log.debug("    {}:".format(name))
+        log.debug(
+            "     document indices in [{}, {}) total of {} " "documents".format(
+                splits[index], splits[index + 1], splits[index + 1] - splits[index]
+            )
+        )
+
+    print_split_stats("train", 0)
+    print_split_stats("validation", 1)
+    print_split_stats("test", 2)
 
     def build_dataset(index, name):
         dataset = None
         if splits[index + 1] > splits[index]:
-            documents = np.arange(start=splits[index], stop=splits[index + 1],
-                                  step=1, dtype=np.int32)
-            dataset = GPTDataset(name, data_prefix, documents, indexed_dataset,
-                                 splits_string,
-                                 train_valid_test_num_samples[index],
-                                 seq_length, seed,
-                                 return_doc_ids,
-                                 data_cache_path=data_cache_path)
+            documents = np.arange(
+                start=splits[index], stop=splits[index + 1], step=1, dtype=np.int32
+            )
+            dataset = GPTDataset(
+                name,
+                data_prefix,
+                documents,
+                indexed_dataset,
+                splits_string,
+                train_valid_test_num_samples[index],
+                seq_length,
+                seed,
+                return_doc_ids,
+                data_cache_path=data_cache_path,
+            )
         return dataset
-    if name.find("train")!=-1:
-        return build_dataset(0, 'train')
-    if name.find("valid")!=-1:
-        return build_dataset(1, 'valid')
-    if name.find("test")!=-1:
-        return build_dataset(2, 'test')
+
+    if name.find("train") != -1:
+        return build_dataset(0, "train")
+    if name.find("valid") != -1:
+        return build_dataset(1, "valid")
+    if name.find("test") != -1:
+        return build_dataset(2, "test")
+
 
 @dlp.log
-def build_dataset(dataset_name, data_prefix, data_impl,
-                  splits_string, num_samples,
-                  seq_length, seed, skip_warmup,
-                  *,
-                  data_cache_path=None):
+def build_dataset(
+    dataset_name,
+    data_prefix,
+    data_impl,
+    splits_string,
+    num_samples,
+    seq_length,
+    seed,
+    skip_warmup,
+    *,
+    data_cache_path=None,
+):
     dataset = None
     if len(data_prefix) == 1:
-        dataset = _build_dataset(dataset_name, data_prefix[0], data_impl,
-                                 splits_string, num_samples, seq_length,
-                                 seed, skip_warmup,
-                                 data_cache_path=data_cache_path)
+        dataset = _build_dataset(
+            dataset_name,
+            data_prefix[0],
+            data_impl,
+            splits_string,
+            num_samples,
+            seq_length,
+            seed,
+            skip_warmup,
+            data_cache_path=data_cache_path,
+        )
     else:
         # Blending dataset.
         # Parse the values.
@@ -366,73 +529,108 @@ def build_dataset(dataset_name, data_prefix, data_impl,
         # Build individual datasets.
         datasets = []
         for i in range(len(prefixes)):
-            ds = _build_dataset(dataset_name, prefixes[i], data_impl,
-                                splits_string, dataset_num_samples[i],
-                                seq_length, seed, skip_warmup,
-                                data_cache_path=data_cache_path)
+            ds = _build_dataset(
+                dataset_name,
+                prefixes[i],
+                data_impl,
+                splits_string,
+                dataset_num_samples[i],
+                seq_length,
+                seed,
+                skip_warmup,
+                data_cache_path=data_cache_path,
+            )
             if ds:
                 datasets.append(ds)
 
         if datasets:
-            dataset = BlendableDataset(datasets, weights, num_samples,
-                                       data_cache_path=data_cache_path)
+            dataset = BlendableDataset(
+                datasets, weights, num_samples, data_cache_path=data_cache_path
+            )
 
     return dataset
 
+
 @dlp.log
-def _build_dataset(dataset_name, data_prefix, data_impl, splits_string,
-                   num_samples, seq_length, seed, skip_warmup,
-                   *,
-                   data_cache_path=None):
+def _build_dataset(
+    dataset_name,
+    data_prefix,
+    data_impl,
+    splits_string,
+    num_samples,
+    seq_length,
+    seed,
+    skip_warmup,
+    *,
+    data_cache_path=None,
+):
     """
     Build dataset. This method is called when individual
     train, valid, test datasets are provided
     """
 
     # Indexed dataset.
-    indexed_dataset = get_indexed_dataset_(data_prefix,
-                                           data_impl,
-                                           skip_warmup)
+    indexed_dataset = get_indexed_dataset_(data_prefix, data_impl, skip_warmup)
 
     total_num_of_documents = indexed_dataset.sizes.shape[0]
 
-    print_rank_0('    {}:'.format(dataset_name))
-    print_rank_0('     document indices in [0, {}) total of {} '
-                 'documents'.format(total_num_of_documents, total_num_of_documents))
+    log.debug("    {}:".format(dataset_name))
+    log.debug(
+        "     document indices in [0, {}) total of {} " "documents".format(
+            total_num_of_documents, total_num_of_documents
+        )
+    )
 
-    documents = np.arange(start=0, stop=total_num_of_documents,
-                        step=1, dtype=np.int32)
+    documents = np.arange(start=0, stop=total_num_of_documents, step=1, dtype=np.int32)
 
-    dataset = GPTDataset(dataset_name, data_prefix, documents, indexed_dataset,
-                         splits_string, num_samples, seq_length, seed,
-                         data_cache_path=data_cache_path)
+    dataset = GPTDataset(
+        dataset_name,
+        data_prefix,
+        documents,
+        indexed_dataset,
+        splits_string,
+        num_samples,
+        seq_length,
+        seed,
+        data_cache_path=data_cache_path,
+    )
 
     return dataset
+
 
 @dlp.log
 def get_indexed_dataset_(data_prefix, data_impl, skip_warmup):
     """Build indexed dataset."""
-    print_rank_0(' > building dataset index ...')
+    log.debug(" > building dataset index ...")
 
     start_time = time.time()
-    indexed_dataset = make_indexed_dataset(data_prefix,
-                                           data_impl,
-                                           skip_warmup)
-    print_rank_0(' > finished creating indexed dataset in {:4f} '
-                 'seconds'.format(time.time() - start_time))
-    print_rank_0('    number of documents: {}'.format(
-        indexed_dataset.sizes.shape[0]))
+    indexed_dataset = make_indexed_dataset(data_prefix, data_impl, skip_warmup)
+    log.debug(
+        " > finished creating indexed dataset in {:4f} " "seconds".format(
+            time.time() - start_time
+        )
+    )
+    log.debug("    number of documents: {}".format(indexed_dataset.sizes.shape[0]))
 
     return indexed_dataset
 
 
 class GPTDataset(torch.utils.data.Dataset):
     @dlp.log
-    def __init__(self, name, data_prefix, documents, indexed_dataset,
-                 splits_string, num_samples, seq_length, seed,
-                 return_doc_ids=False, *,
-                 data_cache_path=None):
-
+    def __init__(
+        self,
+        name,
+        data_prefix,
+        documents,
+        indexed_dataset,
+        splits_string,
+        num_samples,
+        seq_length,
+        seed,
+        return_doc_ids=False,
+        *,
+        data_cache_path=None,
+    ):
         self.name = name
         self.indexed_dataset = indexed_dataset
         self.return_doc_ids = return_doc_ids
@@ -442,20 +640,29 @@ class GPTDataset(torch.utils.data.Dataset):
         assert np.max(documents) < indexed_dataset.sizes.shape[0]
 
         # Build index mappings.
-        self.doc_idx, self.sample_idx, self.shuffle_idx, self.desc, self.desc_hash = \
-            _build_index_mappings(self.name, data_prefix,
-                                  documents, self.indexed_dataset.sizes,
-                                  splits_string, num_samples, seq_length, seed,
-                                  data_cache_path=data_cache_path)
-
+        self.doc_idx, self.sample_idx, self.shuffle_idx, self.desc, self.desc_hash = (
+            _build_index_mappings(
+                self.name,
+                data_prefix,
+                documents,
+                self.indexed_dataset.sizes,
+                splits_string,
+                num_samples,
+                seq_length,
+                seed,
+                data_cache_path=data_cache_path,
+            )
+        )
 
     def __len__(self):
         # -1 is due to data structure used to retieve the index:
         #    sample i --> [sample_idx[i], sample_idx[i+1])
         return self.sample_idx.shape[0] - 1
+
     @dlp.log
     def __getitem__(self, idx):
         args = get_args()
+        assert args is not None
         orig_idx = idx
         # Get the shuffled index.
         try:
@@ -464,21 +671,24 @@ class GPTDataset(torch.utils.data.Dataset):
             if is_rank_0():
                 import json
                 from rich import print_json
+
                 print(exc)
                 print(
-                    '\n'.join(
-                        ['-------------------------------------------------',
-                         f'Trying to access {idx=} from self.shuffle_idx,',
-                         f'but {len(self.shuffle_idx)=}',
-                         '-------------------------------------------------']
+                    "\n".join(
+                        [
+                            "-------------------------------------------------",
+                            f"Trying to access {idx=} from self.shuffle_idx,",
+                            f"but {len(self.shuffle_idx)=}",
+                            "-------------------------------------------------",
+                        ]
                     )
                 )
                 print_json(
                     json.dumps(
                         {
-                            'doc_idx': len(self.doc_idx),
-                            'sample_idx': len(self.sample_idx),
-                            'shuffle_idx': len(self.shuffle_idx),
+                            "doc_idx": len(self.doc_idx),
+                            "sample_idx": len(self.sample_idx),
+                            "shuffle_idx": len(self.shuffle_idx),
                         },
                         indent=4,
                     )
@@ -492,45 +702,57 @@ class GPTDataset(torch.utils.data.Dataset):
         doc_ids = []
         if doc_index_f == doc_index_l:
             doc_ids.append(self.doc_idx[doc_index_f])
-            sample = self.indexed_dataset.get(self.doc_idx[doc_index_f],
-                                              offset=offset_f,
-                                              length=offset_l - offset_f + 1)
+            sample = self.indexed_dataset.get(
+                self.doc_idx[doc_index_f],
+                offset=offset_f,
+                length=offset_l - offset_f + 1,
+            )
         else:
             # Otherwise, get the rest of the initial document.
             doc_ids.append(self.doc_idx[doc_index_f])
-            sample_list = [self.indexed_dataset.get(self.doc_idx[doc_index_f],
-                                                    offset=offset_f)]
+            sample_list = [
+                self.indexed_dataset.get(self.doc_idx[doc_index_f], offset=offset_f)
+            ]
             # Loop over all in between documents and add the entire document.
             for i in range(doc_index_f + 1, doc_index_l):
                 doc_ids.append(self.doc_idx[i])
                 sample_list.append(self.indexed_dataset.get(self.doc_idx[i]))
             # And finally add the relevant portion of last document.
             doc_ids.append(self.doc_idx[doc_index_l])
-            sample_list.append(self.indexed_dataset.get(
-                self.doc_idx[doc_index_l],
-                length=offset_l + 1))
+            sample_list.append(
+                self.indexed_dataset.get(self.doc_idx[doc_index_l], length=offset_l + 1)
+            )
             sample = np.concatenate(sample_list)
 
-        text_name = 'text'
+        text_name = "text"
         if args.use_dataset_only:
-            text_name = 'input_ids'
+            text_name = "input_ids"
         sample_dict = {text_name: np.array(sample, dtype=np.int64)}
         if args.return_data_index:
-            sample_dict.update({'index': np.array([orig_idx], dtype=np.int64)})
+            sample_dict.update({"index": np.array([orig_idx], dtype=np.int64)})
 
-        if self.return_doc_ids: # for retro preprocessing
-            sample_dict.update({'doc_ids': np.array(doc_ids, dtype=np.int64)})
+        if self.return_doc_ids:  # for retro preprocessing
+            sample_dict.update({"doc_ids": np.array(doc_ids, dtype=np.int64)})
 
         if args.use_dataset_only:
-            sample_dict.update({'labels': np.array(sample, dtype=np.int64)})
+            sample_dict.update({"labels": np.array(sample, dtype=np.int64)})
 
         return sample_dict
 
+
 @dlp.log
-def _build_index_mappings(name, data_prefix, documents, sizes,
-                          splits_string, num_samples, seq_length, seed,
-                          *,
-                          data_cache_path):
+def _build_index_mappings(
+    name,
+    data_prefix,
+    documents,
+    sizes,
+    splits_string,
+    num_samples,
+    seq_length,
+    seed,
+    *,
+    data_cache_path,
+):
     """Build doc-idx, sample-idx, and shuffle-idx.
     doc-idx: is an array (ordered) of documents to be used in training.
     sample-idx: is the start document index and document offset for each
@@ -538,10 +760,11 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     shuffle-idx: maps the sample index into a random index into sample-idx.
     """
     args = get_args()
+    assert args is not None
     # Number of tokens in each epoch and number of required epochs.
     tokens_per_epoch = _num_tokens(documents, sizes)
     num_epochs = _num_epochs(tokens_per_epoch, seq_length, num_samples)
-    if args.train_data_exact_num_epochs is not None and name == 'train':
+    if args.train_data_exact_num_epochs is not None and name == "train":
         num_epochs = args.train_data_exact_num_epochs
 
     # rng state
@@ -556,13 +779,13 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     desc += f"Sequence length {seq_length}\n"
     desc += f"Random seed {seed}\n"
     desc += f"Split {splits_string}\n"
-    desc_hash = hashlib.md5(desc.encode('utf-8')).hexdigest()
+    desc_hash = hashlib.md5(desc.encode("utf-8")).hexdigest()
     desc_filename = desc_hash + ".dsc"
-    doc_idx_filename = desc_hash + '_doc_idx.npy'
-    sample_idx_filename = desc_hash + '_sample_idx.npy'
-    shuffle_idx_filename = desc_hash + '_shuffle_idx.npy'
+    doc_idx_filename = desc_hash + "_doc_idx.npy"
+    sample_idx_filename = desc_hash + "_sample_idx.npy"
+    shuffle_idx_filename = desc_hash + "_shuffle_idx.npy"
 
-    if name == 'train':
+    if name == "train":
         # force to use certain index files
         if args.train_desc_path is not None:
             desc_filename = args.train_desc_path
@@ -577,15 +800,15 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     # duplication, then look in data-cache-path if specified,
     # If nothing is found, use the last path looked in
     build_indices = True
-    prefixes = [os.path.join(os.path.dirname(data_prefix), 'index-cache')]
+    prefixes = [os.path.join(os.path.dirname(data_prefix), "index-cache")]
     if data_cache_path is not None:
         prefixes.append(data_cache_path)
     for prefix in prefixes:
         idx_path = {
-            'desc': os.path.join(prefix, desc_filename),
-            'doc': os.path.join(prefix, doc_idx_filename),
-            'sample': os.path.join(prefix, sample_idx_filename),
-            'shuffle': os.path.join(prefix, shuffle_idx_filename)
+            "desc": os.path.join(prefix, desc_filename),
+            "doc": os.path.join(prefix, doc_idx_filename),
+            "sample": os.path.join(prefix, sample_idx_filename),
+            "shuffle": os.path.join(prefix, shuffle_idx_filename),
         }
         for f in idx_path.values():
             if not os.path.isfile(f):
@@ -594,15 +817,17 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
             # Found our files!
             build_indices = False
             break
-    data_cache_dir = os.path.dirname(idx_path['desc'])
+    data_cache_dir = os.path.dirname(idx_path["desc"])
     data_cache_success = True
 
     # Build the indexed mapping if not exist.
     if build_indices:
-        # Since this function will be called by all the rank in the very beginning. Therefore, we assume that all the 
-        # ranks will first create the document files, and then read it. 
+        # Since this function will be called by all the rank in the very beginning. Therefore, we assume that all the
+        # ranks will first create the document files, and then read it.
         # There will not be contension effects going on either
-        print_rank_0(f" > WARNING: could not find index map files, building on rank {torch.distributed.get_rank()}")
+        log.warning(
+            f" > WARNING: could not find index map files, building on rank {torch.distributed.get_rank()}"
+        )
 
         # For the last epoch, decide whether include the entire epoch
         # in the global shuffle or not.
@@ -611,64 +836,80 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
         # not mean anything.
         if num_epochs == 1:
             separate_last_epoch = False
-            print_rank_0(' > only one epoch required, setting '
-                  'separate_last_epoch to False')
+            log.debug(
+                " > only one epoch required, setting " "separate_last_epoch to False"
+            )
 
         else:
             # Get the number of samples for the last epoch
             num_samples_from_epochs_minus_one = (
-                (num_epochs - 1) * tokens_per_epoch - 1) // seq_length
-            last_epoch_num_samples = num_samples - \
-                                     num_samples_from_epochs_minus_one
-            assert last_epoch_num_samples >= 0, \
-                'last epoch number of samples should be non-negative.'
+                (num_epochs - 1) * tokens_per_epoch - 1
+            ) // seq_length
+            last_epoch_num_samples = num_samples - num_samples_from_epochs_minus_one
+            assert (
+                last_epoch_num_samples >= 0
+            ), "last epoch number of samples should be non-negative."
             num_samples_per_epoch = (tokens_per_epoch - 1) // seq_length
-            assert last_epoch_num_samples <= (num_samples_per_epoch + 1), \
-                'last epoch number of samples exceeded max value.'
+            assert last_epoch_num_samples <= (
+                num_samples_per_epoch + 1
+            ), "last epoch number of samples exceeded max value."
             # If we have less than 80% of the samples for the last epoch,
             # seperate out the epoch and treat it differently.
             # Note: the 80% number is just based on common sense and can
             # be adjusted if needed.
-            separate_last_epoch = (last_epoch_num_samples <
-                                   int(0.80 * num_samples_per_epoch))
+            separate_last_epoch = last_epoch_num_samples < int(
+                0.80 * num_samples_per_epoch
+            )
             if separate_last_epoch:
-                string = ' > last epoch number of samples ({}) is smaller '\
-                         'than 80% of number of samples per epoch ({}), '\
-                         'setting separate_last_epoch to True'
+                string = (
+                    " > last epoch number of samples ({}) is smaller "
+                    "than 80% of number of samples per epoch ({}), "
+                    "setting separate_last_epoch to True"
+                )
             else:
-                string = ' > last epoch number of samples ({}) is larger '\
-                         'than 80% of number of samples per epoch ({}), '\
-                         'setting separate_last_epoch to False'
-            print_rank_0(string.format(last_epoch_num_samples,
-                                num_samples_per_epoch))
-
+                string = (
+                    " > last epoch number of samples ({}) is larger "
+                    "than 80% of number of samples per epoch ({}), "
+                    "setting separate_last_epoch to False"
+                )
+            log.debug(string.format(last_epoch_num_samples, num_samples_per_epoch))
 
         try:
             os.makedirs(data_cache_dir, exist_ok=True)
 
             # description
-            with open(idx_path['desc'], 'wt') as fd:
+            with open(idx_path["desc"], "wt") as fd:
                 fd.write(desc)
 
             # doc-idx.
             start_time = time.time()
-            doc_idx = _build_doc_idx(documents, num_epochs, np_rng,
-                                     separate_last_epoch)
-            np.save(idx_path['doc'], doc_idx, allow_pickle=True)
-            print_rank_0(' > elasped time to build and save doc-idx mapping '
-                         '(seconds): {:4f}'.format(time.time() - start_time))
+            doc_idx = _build_doc_idx(documents, num_epochs, np_rng, separate_last_epoch)
+            np.save(idx_path["doc"], doc_idx, allow_pickle=True)
+            log.debug(
+                " > elasped time to build and save doc-idx mapping "
+                "(seconds): {:4f}".format(time.time() - start_time)
+            )
             # sample-idx.
             start_time = time.time()
             # Use C++ implementation for speed.
             # First compile and then import.
             from megatron.data import helpers
+
             assert doc_idx.dtype == np.int32
             assert sizes.dtype == np.int32
-            sample_idx = helpers.build_sample_idx(sizes, doc_idx, seq_length,
-                                                  num_epochs, tokens_per_epoch, torch.distributed.get_rank()==0)
-            np.save(idx_path['sample'], sample_idx, allow_pickle=True)
-            print_rank_0(' > elasped time to build and save sample-idx mapping '
-                         '(seconds): {:4f}'.format(time.time() - start_time))
+            sample_idx = helpers.build_sample_idx(
+                sizes,
+                doc_idx,
+                seq_length,
+                num_epochs,
+                tokens_per_epoch,
+                torch.distributed.get_rank() == 0,
+            )
+            np.save(idx_path["sample"], sample_idx, allow_pickle=True)
+            log.debug(
+                " > elasped time to build and save sample-idx mapping "
+                "(seconds): {:4f}".format(time.time() - start_time)
+            )
             # shuffle-idx.
             start_time = time.time()
             # -1 is due to data structure used to retieve the index:
@@ -677,35 +918,46 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
                 num_samples_ = num_samples_from_epochs_minus_one
             else:
                 num_samples_ = sample_idx.shape[0] - 1
-            shuffle_idx = _build_shuffle_idx(num_samples_,
-                                             sample_idx.shape[0] - 1, np_rng)
-            np.save(idx_path['shuffle'], shuffle_idx, allow_pickle=True)
-            print_rank_0(' > elasped time to build and save shuffle-idx mapping'
-                         ' (seconds): {:4f}'.format(time.time() - start_time))
+            shuffle_idx = _build_shuffle_idx(
+                num_samples_, sample_idx.shape[0] - 1, np_rng
+            )
+            np.save(idx_path["shuffle"], shuffle_idx, allow_pickle=True)
+            log.debug(
+                " > elasped time to build and save shuffle-idx mapping"
+                " (seconds): {:4f}".format(time.time() - start_time)
+            )
         except OSError:
-            print(f'There was an error trying to create the data cache directory ({data_cache_dir})')
-            print('or a file in it. This defaults to a directory "index-cache" within the directory')
-            print('the data files are in and can be set with the --data-cache-path argument. Please')
-            print('ensure you have write access to this directory or specify one that you do have')
-            print('write access to.')
+            print(
+                f"There was an error trying to create the data cache directory ({data_cache_dir})"
+            )
+            print(
+                'or a file in it. This defaults to a directory "index-cache" within the directory'
+            )
+            print(
+                "the data files are in and can be set with the --data-cache-path argument. Please"
+            )
+            print(
+                "ensure you have write access to this directory or specify one that you do have"
+            )
+            print("write access to.")
             data_cache_success = False
 
     # Load mappings.
     start_time = time.time()
-    print_rank_0(f" > loading doc-idx mapping from {idx_path['doc']}")
-    doc_idx = np.load(idx_path['doc'], allow_pickle=True, mmap_mode='r')
+    log.debug(f" > loading doc-idx mapping from {idx_path['doc']}")
+    doc_idx = np.load(idx_path["doc"], allow_pickle=True, mmap_mode="r")
 
-    print_rank_0(f" > loading sample-idx mapping from {idx_path['sample']}")
-    sample_idx = np.load(idx_path['sample'], allow_pickle=True, mmap_mode='r')
+    log.debug(f" > loading sample-idx mapping from {idx_path['sample']}")
+    sample_idx = np.load(idx_path["sample"], allow_pickle=True, mmap_mode="r")
 
-    print_rank_0(f" > loading shuffle-idx mapping from {idx_path['shuffle']}")
-    shuffle_idx = np.load(idx_path['shuffle'], allow_pickle=True, mmap_mode='r')
+    log.debug(f" > loading shuffle-idx mapping from {idx_path['shuffle']}")
+    shuffle_idx = np.load(idx_path["shuffle"], allow_pickle=True, mmap_mode="r")
 
-    print_rank_0('    loaded indexed file in {:3.3f} seconds'.format(
-        time.time() - start_time))
-    print_rank_0('    total number of samples: {}'.format(
-        sample_idx.shape[0]))
-    print_rank_0('    total number of epochs: {}'.format(num_epochs))
+    log.debug(
+        "    loaded indexed file in {:3.3f} seconds".format(time.time() - start_time)
+    )
+    log.debug("    total number of samples: {}".format(sample_idx.shape[0]))
+    log.debug("    total number of epochs: {}".format(num_epochs))
 
     return doc_idx, sample_idx, shuffle_idx, desc, desc_hash
 
@@ -729,25 +981,26 @@ def _num_epochs(tokens_per_epoch, seq_length, num_samples):
         if ((total_tokens - 1) // seq_length) >= num_samples:
             return num_epochs
 
+
 @dlp.log
 def _build_doc_idx(documents, num_epochs, np_rng, separate_last_epoch):
     """Build an array with length = number-of-epochs * number-of-dcuments.
     Each index is mapped to a corresponding document."""
     if not separate_last_epoch or num_epochs == 1:
-        doc_idx = np.mgrid[0:num_epochs, 0:len(documents)][1]
+        doc_idx = np.mgrid[0:num_epochs, 0 : len(documents)][1]
         doc_idx[:] = documents
         doc_idx = doc_idx.reshape(-1)
         doc_idx = doc_idx.astype(np.int32)
         np_rng.shuffle(doc_idx)
         return doc_idx
 
-    doc_idx_first = _build_doc_idx(documents, num_epochs-1, np_rng, False)
+    doc_idx_first = _build_doc_idx(documents, num_epochs - 1, np_rng, False)
     doc_idx_last = _build_doc_idx(documents, 1, np_rng, False)
     return np.concatenate((doc_idx_first, doc_idx_last))
 
+
 @dlp.log
-def _build_sample_idx(sizes, doc_idx, seq_length,
-                      num_epochs, tokens_per_epoch):
+def _build_sample_idx(sizes, doc_idx, seq_length, num_epochs, tokens_per_epoch):
     """Sample index mapping is a 2D array with sizes
     [number-of-samples + 1, 2] where [..., 0] contains
     the index into `doc_idx` and [..., 1] is the
@@ -781,7 +1034,7 @@ def _build_sample_idx(sizes, doc_idx, seq_length,
             # Note that -1 here is for the same reason we have -1 in
             # `_num_epochs` calculations.
             if remaining_seq_length <= 0:
-                doc_offset += (remaining_seq_length + doc_length - 1)
+                doc_offset += remaining_seq_length + doc_length - 1
                 remaining_seq_length = 0
             else:
                 # Otherwise, start from the begining of the next document.
@@ -794,24 +1047,28 @@ def _build_sample_idx(sizes, doc_idx, seq_length,
 
     return sample_idx
 
+
 @dlp.log
 def _build_shuffle_idx(num_samples, total_size, np_rng):
     """Build the range [0, size) and shuffle."""
-    print_rank_0(' > building shuffle index with split [0, {}) and [{}, {}) '
-          '...'.format(num_samples, num_samples, total_size))
+    log.debug(
+        " > building shuffle index with split [0, {}) and [{}, {}) " "...".format(
+            num_samples, num_samples, total_size
+        )
+    )
 
     dtype_ = np.uint32
     if total_size >= (np.iinfo(np.uint32).max - 1):
         dtype_ = np.int64
 
-    shuffle_idx_first = np.arange(start=0, stop=num_samples,
-                                  step=1, dtype=dtype_)
+    shuffle_idx_first = np.arange(start=0, stop=num_samples, step=1, dtype=dtype_)
     np_rng.shuffle(shuffle_idx_first)
     if num_samples == total_size:
         return shuffle_idx_first
 
-    shuffle_idx_last = np.arange(start=num_samples, stop=total_size,
-                                 step=1, dtype=dtype_)
+    shuffle_idx_last = np.arange(
+        start=num_samples, stop=total_size, step=1, dtype=dtype_
+    )
     np_rng.shuffle(shuffle_idx_last)
 
     return np.concatenate((shuffle_idx_first, shuffle_idx_last))

--- a/megatron/data/gpt_dataset.py
+++ b/megatron/data/gpt_dataset.py
@@ -133,7 +133,7 @@ def build_train_valid_test_datasets(
 
         class BuildConcatDataset(torch.utils.data.Dataset):
             @dlp.log
-            def __init__(self, dataset_builders):
+            def __init__(self, dataset_builders, shuffle=False):
                 self.dataset_builders = dataset_builders
                 self.num_datasets = len(dataset_builders)
                 self.num_samples = np.sum([d.num_samples for d in dataset_builders])
@@ -163,7 +163,8 @@ def build_train_valid_test_datasets(
                 self.dataset_index, self.dataset_sample_index = _build_indices()
                 np_rng = np.random.RandomState(seed=dataset_builders[0].seed)
                 self.shuffle_index = np.arange(self.num_samples)
-                np_rng.shuffle(self.shuffle_index)
+                if shuffle:
+                    np_rng.shuffle(self.shuffle_index)
                 for i in range(self.num_datasets):
                     self.desc += dataset_builders[i].prefix + ","
 
@@ -196,7 +197,7 @@ def build_train_valid_test_datasets(
         valid_datasets = []
         test_datasets = []
         # Build individual datasets.
-
+        args = get_args()
         @dlp.log
         def build_corpus_datasets(dataset_type="train"):
             start_time = time.time()
@@ -242,7 +243,7 @@ def build_train_valid_test_datasets(
             log.debug(" > number of samples for each corpus ")
             corpus_weights_achieved = {}
             for c in corpus_list:
-                datasets.append(BuildConcatDataset(corpus_builders[c]))
+                datasets.append(BuildConcatDataset(corpus_builders[c], args.shuffle_sample))
                 total += datasets[-1].num_samples
                 corpus_weights_achieved[c] = (
                     float(datasets[-1].num_samples) / train_num_samples

--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -15,16 +15,23 @@
 
 from functools import lru_cache
 import os
+
+# import logging
 import shutil
 import struct
 from itertools import accumulate
 
 import numpy as np
 import torch
-from megatron import print_rank_0
-from megatron.utils import Profile
+
+# from megatron import print_rank_0
+from megatron.utils import Profile, get_logger
+
+log = get_logger(__name__)
+
 
 dlp = Profile("DATASET")
+
 
 def __best_fitting_dtype(vocab_size=None):
     if vocab_size is not None and vocab_size < 65500:
@@ -34,28 +41,32 @@ def __best_fitting_dtype(vocab_size=None):
 
 
 def get_available_dataset_impl():
-    return ['lazy', 'cached', 'mmap']
+    return ["lazy", "cached", "mmap"]
 
 
 def infer_dataset_impl(path):
     if IndexedDataset.exists(path):
-        with open(index_file_path(path), 'rb') as f:
+        with open(index_file_path(path), "rb") as f:
             magic = f.read(8)
             if magic == IndexedDataset._HDR_MAGIC:
-                return 'cached'
+                return "cached"
             elif magic == MMapIndexedDataset.Index._HDR_MAGIC[:8]:
-                return 'mmap'
+                return "mmap"
             else:
                 return None
     else:
         print(f"Dataset does not exist: {path}")
-        print("Path should be a basename that both .idx and .bin can be appended to get full filenames.")
+        print(
+            "Path should be a basename that both .idx and .bin can be appended to get full filenames."
+        )
         return None
 
 
 def make_builder(out_file, impl, vocab_size=None):
-    if impl == 'mmap':
-        return MMapIndexedDatasetBuilder(out_file, dtype=__best_fitting_dtype(vocab_size))
+    if impl == "mmap":
+        return MMapIndexedDatasetBuilder(
+            out_file, dtype=__best_fitting_dtype(vocab_size)
+        )
     else:
         return IndexedDatasetBuilder(out_file)
 
@@ -63,22 +74,24 @@ def make_builder(out_file, impl, vocab_size=None):
 def make_dataset(path, impl, skip_warmup=False):
     if not IndexedDataset.exists(path):
         print(f"Dataset does not exist: {path}")
-        print("Path should be a basename that both .idx and .bin can be appended to get full filenames.")
+        print(
+            "Path should be a basename that both .idx and .bin can be appended to get full filenames."
+        )
         return None
-    if impl == 'infer':
+    if impl == "infer":
         impl = infer_dataset_impl(path)
-    if impl == 'lazy' and IndexedDataset.exists(path):
+    if impl == "lazy" and IndexedDataset.exists(path):
         return IndexedDataset(path)
-    elif impl == 'cached' and IndexedDataset.exists(path):
+    elif impl == "cached" and IndexedDataset.exists(path):
         return IndexedCachedDataset(path)
-    elif impl == 'mmap' and MMapIndexedDataset.exists(path):
+    elif impl == "mmap" and MMapIndexedDataset.exists(path):
         return MMapIndexedDataset(path, skip_warmup)
     print(f"Unknown dataset implementation: {impl}")
     return None
 
 
 def dataset_exists(path, impl):
-    if impl == 'mmap':
+    if impl == "mmap":
         return MMapIndexedDataset.exists(path)
     else:
         return IndexedDataset.exists(path)
@@ -114,11 +127,11 @@ def code(dtype):
 
 
 def index_file_path(prefix_path):
-    return prefix_path + '.idx'
+    return prefix_path + ".idx"
 
 
 def data_file_path(prefix_path):
-    return prefix_path + '.bin'
+    return prefix_path + ".bin"
 
 
 def create_doc_idx(sizes):
@@ -131,38 +144,41 @@ def create_doc_idx(sizes):
 
 class IndexedDataset(torch.utils.data.Dataset):
     """Loader for IndexedDataset"""
-    _HDR_MAGIC = b'TNTIDX\x00\x00'
+
+    _HDR_MAGIC = b"TNTIDX\x00\x00"
 
     def __init__(self, path):
         super().__init__()
         self.path = path
         self.data_file = None
         self.read_index(path)
+
     @dlp.log
     def read_index(self, path):
-        with open(index_file_path(path), 'rb') as f:
+        with open(index_file_path(path), "rb") as f:
             magic = f.read(8)
             assert magic == self._HDR_MAGIC, (
-                'Index file doesn\'t match expected format. '
-                'Make sure that --dataset-impl is configured properly.'
+                "Index file doesn't match expected format. "
+                "Make sure that --dataset-impl is configured properly."
             )
             version = f.read(8)
-            assert struct.unpack('<Q', version) == (1,)
-            code, self.element_size = struct.unpack('<QQ', f.read(16))
+            assert struct.unpack("<Q", version) == (1,)
+            code, self.element_size = struct.unpack("<QQ", f.read(16))
             self.dtype = dtypes[code]
-            self._len, self.s = struct.unpack('<QQ', f.read(16))
-            self.doc_count = struct.unpack('<Q', f.read(8))
+            self._len, self.s = struct.unpack("<QQ", f.read(16))
+            self.doc_count = struct.unpack("<Q", f.read(8))
             self.dim_offsets = read_longs(f, self._len + 1)
             self.data_offsets = read_longs(f, self._len + 1)
             self.sizes = read_longs(f, self.s)
             self.doc_idx = read_longs(f, self.doc_count)
+
     @dlp.log
     def read_data(self, path):
-        self.data_file = open(data_file_path(path), 'rb', buffering=0)
+        self.data_file = open(data_file_path(path), "rb", buffering=0)
 
     def check_index(self, i):
         if i < 0 or i >= self._len:
-            raise IndexError('index out of range')
+            raise IndexError("index out of range")
 
     def __del__(self):
         if self.data_file:
@@ -176,7 +192,7 @@ class IndexedDataset(torch.utils.data.Dataset):
         if isinstance(idx, int):
             i = idx
             self.check_index(i)
-            tensor_size = self.sizes[self.dim_offsets[i]:self.dim_offsets[i + 1]]
+            tensor_size = self.sizes[self.dim_offsets[i] : self.dim_offsets[i + 1]]
             a = np.empty(tensor_size, dtype=self.dtype)
             self.data_file.seek(self.data_offsets[i] * self.element_size)
             self.data_file.readinto(a)
@@ -185,7 +201,7 @@ class IndexedDataset(torch.utils.data.Dataset):
             start, stop, step = idx.indices(len(self))
             if step != 1:
                 raise ValueError("Slices into indexed_dataset must be contiguous")
-            sizes = self.sizes[self.dim_offsets[start]:self.dim_offsets[stop]]
+            sizes = self.sizes[self.dim_offsets[start] : self.dim_offsets[stop]]
             size = sum(sizes)
             a = np.empty(size, dtype=self.dtype)
             self.data_file.seek(self.data_offsets[start] * self.element_size)
@@ -205,8 +221,8 @@ class IndexedDataset(torch.utils.data.Dataset):
 
     @staticmethod
     def exists(path):
-        return (
-            os.path.exists(index_file_path(path)) and os.path.exists(data_file_path(path))
+        return os.path.exists(index_file_path(path)) and os.path.exists(
+            data_file_path(path)
         )
 
     @property
@@ -215,7 +231,6 @@ class IndexedDataset(torch.utils.data.Dataset):
 
 
 class IndexedCachedDataset(IndexedDataset):
-
     def __init__(self, path):
         super().__init__(path)
         self.cache = None
@@ -224,6 +239,7 @@ class IndexedCachedDataset(IndexedDataset):
     @property
     def supports_prefetch(self):
         return True
+
     @dlp.log
     def prefetch(self, indices):
         if all(i in self.cache_index for i in indices):
@@ -240,7 +256,7 @@ class IndexedCachedDataset(IndexedDataset):
         for i in indices:
             self.cache_index[i] = ptx
             size = self.data_offsets[i + 1] - self.data_offsets[i]
-            a = self.cache[ptx: ptx + size]
+            a = self.cache[ptx : ptx + size]
             self.data_file.seek(self.data_offsets[i] * self.element_size)
             self.data_file.readinto(a)
             ptx += size
@@ -255,10 +271,10 @@ class IndexedCachedDataset(IndexedDataset):
         if isinstance(idx, int):
             i = idx
             self.check_index(i)
-            tensor_size = self.sizes[self.dim_offsets[i]:self.dim_offsets[i + 1]]
+            tensor_size = self.sizes[self.dim_offsets[i] : self.dim_offsets[i + 1]]
             a = np.empty(tensor_size, dtype=self.dtype)
             ptx = self.cache_index[i]
-            np.copyto(a, self.cache[ptx: ptx + a.size])
+            np.copyto(a, self.cache[ptx : ptx + a.size])
             return a
         elif isinstance(idx, slice):
             # Hack just to make this work, can optimizer later if necessary
@@ -278,15 +294,17 @@ class IndexedDatasetBuilder(object):
         np.float32: 4,
         np.float64: 8,
     }
+
     @dlp.log
     def __init__(self, out_file, dtype=np.int32):
-        self.out_file = open(out_file, 'wb')
+        self.out_file = open(out_file, "wb")
         self.dtype = dtype
         self.data_offsets = [0]
         self.dim_offsets = [0]
         self.sizes = []
         self.element_size = self.element_sizes[self.dtype]
         self.doc_idx = [0]
+
     @dlp.log
     def add_item(self, tensor):
         bytes = self.out_file.write(np.array(tensor.numpy(), dtype=self.dtype))
@@ -297,6 +315,7 @@ class IndexedDatasetBuilder(object):
 
     def end_document(self):
         self.doc_idx.append(len(self.sizes))
+
     @dlp.log
     def merge_file_(self, another_file):
         index = IndexedDataset(another_file)
@@ -315,7 +334,7 @@ class IndexedDatasetBuilder(object):
 
         self.doc_idx.extend((doc_offset + index.doc_idx)[1:])
 
-        with open(data_file_path(another_file), 'rb') as f:
+        with open(data_file_path(another_file), "rb") as f:
             while True:
                 data = f.read(1024)
                 if data:
@@ -325,21 +344,22 @@ class IndexedDatasetBuilder(object):
 
     def finalize(self, index_file):
         self.out_file.close()
-        index = open(index_file, 'wb')
-        index.write(b'TNTIDX\x00\x00')
-        index.write(struct.pack('<Q', 1))
-        index.write(struct.pack('<QQ', code(self.dtype), self.element_size))
-        index.write(struct.pack('<QQ', len(self.data_offsets) - 1, len(self.sizes)))
-        index.write(struct.pack('<Q', len(self.doc_idx)))
+        index = open(index_file, "wb")
+        index.write(b"TNTIDX\x00\x00")
+        index.write(struct.pack("<Q", 1))
+        index.write(struct.pack("<QQ", code(self.dtype), self.element_size))
+        index.write(struct.pack("<QQ", len(self.data_offsets) - 1, len(self.sizes)))
+        index.write(struct.pack("<Q", len(self.doc_idx)))
         write_longs(index, self.dim_offsets)
         write_longs(index, self.data_offsets)
         write_longs(index, self.sizes)
         write_longs(index, self.doc_idx)
         index.close()
 
+
 @dlp.log
 def _warmup_mmap_file(path):
-    with open(path, 'rb') as stream:
+    with open(path, "rb") as stream:
         while stream.read(100 * 1024 * 1024):
             pass
 
@@ -378,17 +398,17 @@ def get_pointers_with_total(sizes, elemsize, dtype):
 
 class MMapIndexedDataset(torch.utils.data.Dataset):
     class Index(object):
-        _HDR_MAGIC = b'MMIDIDX\x00\x00'
+        _HDR_MAGIC = b"MMIDIDX\x00\x00"
 
         @classmethod
         def writer(cls, path, dtype):
             class _Writer(object):
                 def __enter__(self):
-                    self._file = open(path, 'wb')
+                    self._file = open(path, "wb")
 
                     self._file.write(cls._HDR_MAGIC)
-                    self._file.write(struct.pack('<Q', 1))
-                    self._file.write(struct.pack('<B', code(dtype)))
+                    self._file.write(struct.pack("<Q", 1))
+                    self._file.write(struct.pack("<B", code(dtype)))
 
                     return self
 
@@ -401,24 +421,27 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
                     """
 
                     # compute element sizes in bytes
-                    pointers, _ = get_pointers_with_total(sizes, dtype().itemsize, npdtype)
+                    pointers, _ = get_pointers_with_total(
+                        sizes, dtype().itemsize, npdtype
+                    )
                     return pointers
+
                 @dlp.log
                 def write(self, sizes, doc_idx):
-                    self._file.write(struct.pack('<Q', len(sizes)))
-                    self._file.write(struct.pack('<Q', len(doc_idx)))
+                    self._file.write(struct.pack("<Q", len(sizes)))
+                    self._file.write(struct.pack("<Q", len(doc_idx)))
 
                     sizes32 = np.array(sizes, dtype=np.int32)
-                    self._file.write(sizes32.tobytes(order='C'))
+                    self._file.write(sizes32.tobytes(order="C"))
                     del sizes32
 
                     pointers = self._get_pointers(sizes, np.int64)
                     del sizes
-                    self._file.write(pointers.tobytes(order='C'))
+                    self._file.write(pointers.tobytes(order="C"))
                     del pointers
 
                     doc_idx = np.array(doc_idx, dtype=np.int64)
-                    self._file.write(doc_idx.tobytes(order='C'))
+                    self._file.write(doc_idx.tobytes(order="C"))
 
                 def __exit__(self, exc_type, exc_val, exc_tb):
                     self._file.close()
@@ -427,41 +450,47 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
 
         @dlp.log
         def __init__(self, path, skip_warmup=False):
-            with open(path, 'rb') as stream:
+            with open(path, "rb") as stream:
                 magic_test = stream.read(9)
                 assert self._HDR_MAGIC == magic_test, (
-                    'Index file doesn\'t match expected format. '
-                    'Make sure that --dataset-impl is configured properly.'
+                    "Index file doesn't match expected format. "
+                    "Make sure that --dataset-impl is configured properly."
                 )
-                version = struct.unpack('<Q', stream.read(8))
+                version = struct.unpack("<Q", stream.read(8))
                 assert (1,) == version
 
-                dtype_code, = struct.unpack('<B', stream.read(1))
+                (dtype_code,) = struct.unpack("<B", stream.read(1))
                 self._dtype = dtypes[dtype_code]
                 self._dtype_size = self._dtype().itemsize
 
-                self._len = struct.unpack('<Q', stream.read(8))[0]
-                self._doc_count = struct.unpack('<Q', stream.read(8))[0]
+                self._len = struct.unpack("<Q", stream.read(8))[0]
+                self._doc_count = struct.unpack("<Q", stream.read(8))[0]
                 offset = stream.tell()
 
             if not skip_warmup:
-                print_rank_0("    warming up index mmap file...")
+                log.debug("    warming up index mmap file...")
                 _warmup_mmap_file(path)
 
-            self._bin_buffer_mmap = np.memmap(path, mode='r', order='C')
+            self._bin_buffer_mmap = np.memmap(path, mode="r", order="C")
             self._bin_buffer = memoryview(self._bin_buffer_mmap)
-            print_rank_0("    reading sizes...")
+            log.debug("    reading sizes...")
             self._sizes = np.frombuffer(
+                self._bin_buffer, dtype=np.int32, count=self._len, offset=offset
+            )
+            log.debug("    reading pointers...")
+            self._pointers = np.frombuffer(
                 self._bin_buffer,
-                dtype=np.int32,
+                dtype=np.int64,
                 count=self._len,
-                offset=offset)
-            print_rank_0("    reading pointers...")
-            self._pointers = np.frombuffer(self._bin_buffer, dtype=np.int64, count=self._len,
-                                           offset=offset + self._sizes.nbytes)
-            print_rank_0("    reading document index...")
-            self._doc_idx = np.frombuffer(self._bin_buffer, dtype=np.int64, count=self._doc_count,
-                                          offset=offset + self._sizes.nbytes + self._pointers.nbytes)
+                offset=offset + self._sizes.nbytes,
+            )
+            log.debug("    reading document index...")
+            self._doc_idx = np.frombuffer(
+                self._bin_buffer,
+                dtype=np.int64,
+                count=self._doc_count,
+                offset=offset + self._sizes.nbytes + self._pointers.nbytes,
+            )
 
         def __del__(self):
             self._bin_buffer_mmap._mmap.close()
@@ -507,12 +536,14 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
         self._index = self.Index(index_file_path(self._path), skip_warmup)
 
         if not skip_warmup:
-            print_rank_0("    warming up data mmap file...")
+            log.debug("    warming up data mmap file...")
             _warmup_mmap_file(data_file_path(self._path))
-        print_rank_0("    creating numpy buffer of mmap...")
-        print_rank_0(data_file_path(self._path))
-        self._bin_buffer_mmap = np.memmap(data_file_path(self._path), mode='r', order='C')
-        print_rank_0("    creating memory view of numpy buffer...")
+        log.debug("    creating numpy buffer of mmap...")
+        log.debug(data_file_path(self._path))
+        self._bin_buffer_mmap = np.memmap(
+            data_file_path(self._path), mode="r", order="C"
+        )
+        log.debug("    creating memory view of numpy buffer...")
         self._bin_buffer = memoryview(self._bin_buffer_mmap)
 
     def __del__(self):
@@ -528,8 +559,9 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
     def __getitem__(self, idx):
         if isinstance(idx, (int, np.integer)):
             ptr, size = self._index[idx]
-            np_array = np.frombuffer(self._bin_buffer, dtype=self._index.dtype,
-                                     count=size, offset=ptr)
+            np_array = np.frombuffer(
+                self._bin_buffer, dtype=self._index.dtype, count=size, offset=ptr
+            )
             return np_array
         elif isinstance(idx, slice):
             start, stop, step = idx.indices(len(self))
@@ -539,8 +571,9 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
             sizes = self._index._sizes[idx]
             offsets = list(accumulate(sizes))
             total_size = sum(sizes)
-            np_array = np.frombuffer(self._bin_buffer, dtype=self._index.dtype,
-                                     count=total_size, offset=ptr)
+            np_array = np.frombuffer(
+                self._bin_buffer, dtype=self._index.dtype, count=total_size, offset=ptr
+            )
             sents = np.split(np_array, offsets[:-1])
             return sents
         else:
@@ -548,7 +581,7 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
 
     @dlp.log
     def get(self, idx, offset=0, length=None):
-        """ Retrieves a single item from the dataset with the option to only
+        """Retrieves a single item from the dataset with the option to only
         return a portion of the item.
 
         get(idx) is the same as [idx] but get() does not support slicing.
@@ -557,8 +590,9 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
         if length is None:
             length = size - offset
         ptr += offset * np.dtype(self._index.dtype).itemsize
-        np_array = np.frombuffer(self._bin_buffer, dtype=self._index.dtype,
-                                 count=length, offset=ptr)
+        np_array = np.frombuffer(
+            self._bin_buffer, dtype=self._index.dtype, count=length, offset=ptr
+        )
         return np_array
 
     @property
@@ -584,8 +618,8 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
 
     @staticmethod
     def exists(path):
-        return (
-            os.path.exists(index_file_path(path)) and os.path.exists(data_file_path(path))
+        return os.path.exists(index_file_path(path)) and os.path.exists(
+            data_file_path(path)
         )
 
     @property
@@ -595,24 +629,27 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
 
 class MMapIndexedDatasetBuilder(object):
     def __init__(self, out_file, dtype=np.int64):
-        self._data_file = open(out_file, 'wb')
+        self._data_file = open(out_file, "wb")
         self._dtype = dtype
         self._sizes = []
         self._doc_idx = [0]
+
     @dlp.log
     def add_item(self, tensor):
         np_array = np.array(tensor.numpy(), dtype=self._dtype)
-        self._data_file.write(np_array.tobytes(order='C'))
+        self._data_file.write(np_array.tobytes(order="C"))
         self._sizes.append(np_array.size)
+
     @dlp.log
     def add_doc(self, tensor, sizes):
         np_array = np.array(tensor, dtype=self._dtype)
-        self._data_file.write(np_array.tobytes(order='C'))
+        self._data_file.write(np_array.tobytes(order="C"))
         self._sizes.extend(sizes)
         self._doc_idx.append(len(self._sizes))
 
     def end_document(self):
         self._doc_idx.append(len(self._sizes))
+
     @dlp.log
     def merge_file_(self, another_file):
         # Concatenate index
@@ -624,7 +661,7 @@ class MMapIndexedDatasetBuilder(object):
         self._doc_idx.extend((offset + index.doc_idx)[1:])
 
         # Concatenate data
-        with open(data_file_path(another_file), 'rb') as f:
+        with open(data_file_path(another_file), "rb") as f:
             shutil.copyfileobj(f, self._data_file)
 
     def finalize(self, index_file):

--- a/pretrain_gpt_alcf.py
+++ b/pretrain_gpt_alcf.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
 
 """Pretrain GPT"""
+
 import time
 from typing import Callable
 from mpi4py import MPI
@@ -103,7 +104,7 @@ def model_provider(pre_process=True, post_process=True):
     with deepspeed_zero_init(
         data_parallel_group=dpg,
         remote_device=(None if args.remote_device == "none" else args.remote_device),
-        config_dict_or_path=args.deepspeed_config_dict,
+        config_dict_or_path=args.deepspeed_config,  # _dict,
         enabled=args.zero_stage == 3,
         mpu=mpu,
     ):

--- a/train_aGPT_7B.sh
+++ b/train_aGPT_7B.sh
@@ -16,19 +16,20 @@ source "${HERE}/ALCF/helpers.sh" || exit
 
 # 3. call `setup` from `./ALCF/helpers.sh`
 setup "$@" || exit
-export run_cmd="${run_cmd}"
-echo "${run_cmd}" | tee -a "${OUTPUT_LOG}"
+# export run_cmd="${run_cmd}"
+echo "${run_cmd[@]}" | tee -a "${OUTPUT_LOG}"
 
 # 4. Tell user where to find output
 printf "[!! %s] View output at:\n %s\n" "$(printBlue "NOTE")" "$(printYellow "${OUTPUT_LOG}")" | tee -a "${OUTPUT_LOG}"
 
-# 5. Ignore the following strings on Intel XPU devices
-#    (otherwise they'll clutter up logs)
-XPU_IGNORE_STRING="CCL_WARN|\ -\ INFO\ \-\ |real_accelerator\.py|numexpr\.utils|async_io|libaio"
+# # 5. Ignore the following strings on Intel XPU devices
+# #    (otherwise they'll clutter up logs)
+# XPU_IGNORE_STRING="CCL_WARN|\ -\ INFO\ \-\ |real_accelerator\.py|numexpr\.utils|async_io|libaio"
 
 # if [[ $(ezpz_get_machine_name) == "aurora" ]]; then
 #     module unload mpich && module load mpich
 # fi
 #
 # 6. Evaluate ${run_cmd} and append outputs to ${OUTPUT_LOG}
-eval "${run_cmd}" |& grep -E -v "${XPU_IGNORE_STRING}" |& tee -a "${OUTPUT_LOG}"
+# eval "${run_cmd[@]}" |& tee -a "${OUTPUT_LOG}"
+eval "${run_cmd[*]}" |& tee -a "${OUTPUT_LOG}"


### PR DESCRIPTION
# Various quality of life improvements

## Logging Improvements

- Replace calls to `print_rank_0` with an appropriate `logging` call in `megatron/data/{gpt_dataset.py,blendable_dataset.py,indexed_dataset.py}`

  - Additionally, we set the logging level to be `DEBUG` by default in `megatron/data/gpt_dataset.py`

  - Previously, these logs were quite verbose and printed a lot of information that, while valuable, really cluttered up the logs.

  <details closed><summary><code>LOG_LEVEL=INFO</code> (<b>DEFAULT</b>) </summary>
  
  ```bash
  [2024-10-13 10:35:15.801675][INFO][training_log.py:661] -  iteration=      21/  105963 | consumed_samples=       10368 | consumed_tokens=    42467328 | elapsed_time_per_iteration_ms=33736.1 | learning_rate=1.27402e-07 | global_batch_size= 4608 | lm loss=11.192327 | grad_norm=6.567 | actual_seqlen= 4096 | number_of_skipped_iterations=  0 | number_of_nan_iterations=  0 | samples_per_second=136.590 | tokens_per_gpu_per_second_tgs=5827.827 | [LM]TFLOPs=48.80 | [DS]TFLOPs=62.72 |
  [2024-10-13 10:35:15.803942][INFO][utils.py:249] - [Rank 0] (after 21 iterations) memory (MB) | allocated: 10272.43798828125 | max allocated: 46425.61083984375 | reserved: 58130.0 | max reserved: 58130.0
  [2024-10-13 10:35:36,499] [INFO] [logging.py:96:log_dist] [Rank 0] step=22, skipped=0, lr=[1.8402508875376674e-07, 1.8402508875376674e-07], mom=[(0.9, 0.95), (0.9, 0.95)]
  [2024-10-13 10:35:36,500] [INFO] [logging.py:96:log_dist] [Rank 0] time (ms) | fwd_microstep: 4635.16 | bwd_microstep: 15678.70 | bwd_inner_microstep: 14110.46 | bwd_allreduce_microstep: 1568.21 | step_microstep: 326.84
  [2024-10-13 10:35:36,500] [INFO] [logging.py:96:log_dist] [Rank 0] time (ms) | fwd: 4635.16 | bwd: 15678.70 | bwd_inner: 14110.46 | bwd_allreduce: 1568.21 | step: 326.84
  [2024-10-13 10:35:36.513118][INFO][training_log.py:661] -  iteration=      22/  105963 | consumed_samples=       14976 | consumed_tokens=    61341696 | elapsed_time_per_iteration_ms=20711.3 | learning_rate=1.84025e-07 | global_batch_size= 4608 | lm loss=11.192505 | grad_norm=6.578 | actual_seqlen= 4096 | number_of_skipped_iterations=  0 | number_of_nan_iterations=  0 | samples_per_second=222.488 | tokens_per_gpu_per_second_tgs=9492.801 | [LM]TFLOPs=79.49 | [DS]TFLOPs=102.17 |
  ```
  
  </details>
  
  <details closed><summary><code>LOG_LEVEL=DEBUG</code></summary>
  
  **NOTE**: The log level will **only** be set to `DEBUG` if the variable

  ```bash
  LOG_LEVEL=DEBUG bash train_aGPT_7B.sh
  ```

  is caught in the running environment[^filtered].

  ```bash
  [2024-10-13 10:38:52.986261][INFO][training_log.py:661] -  iteration=      21/  105963 | consumed_samples=       10368 | consumed_tokens=    42467328 | elapsed_time_per_iteration_ms=29754.2 | learning_rate=1.27402e-07 | global_batch_size= 4608 | lm loss=11.192327 | grad_norm=6.567 | actual_seqlen= 4096 | number_of_skipped_iterations=  0 | number_of_nan_iterations=  0 | samples_per_second=154.869 | tokens_per_gpu_per_second_tgs=6607.731 | [LM]TFLOPs=55.33 | [DS]TFLOPs=71.12 |
  [2024-10-13 10:38:52.988508][INFO][utils.py:249] - [Rank 0] (after 21 iterations) memory (MB) | allocated: 10272.43798828125 | max allocated: 46425.61083984375 | reserved: 58130.0 | max reserved: 58130.0
  [2024-10-13 10:38:52.995778][DEBUG][gpt_dataset.py:446] -  >> building dataset for /flare/Aurora_deployment/AuroraGPT/datasets/dolma/data_v1.7_Llama2Tokenizer/stackexchange-0009_text_document
  [2024-10-13 10:38:52.996706][DEBUG][gpt_dataset.py:604] -  > building dataset index ...
  [2024-10-13 10:38:52.999996][DEBUG][indexed_dataset.py:476] -     reading sizes...
  [2024-10-13 10:38:53.000761][DEBUG][indexed_dataset.py:480] -     reading pointers...
  [2024-10-13 10:38:53.001260][DEBUG][indexed_dataset.py:487] -     reading document index...
  [2024-10-13 10:38:53.001737][DEBUG][indexed_dataset.py:541] -     creating numpy buffer of mmap...
  [2024-10-13 10:38:53.002212][DEBUG][indexed_dataset.py:542] - /flare/Aurora_deployment/AuroraGPT/datasets/dolma/data_v1.7_Llama2Tokenizer/stackexchange-0009_text_document.bin
  [2024-10-13 10:38:53.002807][DEBUG][indexed_dataset.py:546] -     creating memory view of numpy buffer...
  [2024-10-13 10:38:53.003338][DEBUG][gpt_dataset.py:608] -  > finished creating indexed dataset in 0.006100 seconds
  [2024-10-13 10:38:53.003861][DEBUG][gpt_dataset.py:613] -     number of documents: 1137635
  [2024-10-13 10:38:53.004351][DEBUG][gpt_dataset.py:454] -  > dataset split:
  [2024-10-13 10:38:53.004785][DEBUG][gpt_dataset.py:457] -     train:
  [2024-10-13 10:38:53.005214][DEBUG][gpt_dataset.py:458] -      document indices in [0, 1137635) total of 1137635 documents
  [2024-10-13 10:38:53.005793][DEBUG][gpt_dataset.py:457] -     validation:
  [2024-10-13 10:38:53.006226][DEBUG][gpt_dataset.py:458] -      document indices in [1137635, 1137635) total of 0 documents
  [2024-10-13 10:38:53.006762][DEBUG][gpt_dataset.py:457] -     test:
  [2024-10-13 10:38:53.007157][DEBUG][gpt_dataset.py:458] -      document indices in [1137635, 1137635) total of 0 documents
  [2024-10-13 10:38:53.021128][DEBUG][gpt_dataset.py:947] -  > loading doc-idx mapping from checkpoints/ds_stage0_nl6_hs4096_mb12_seq4096_sp1_pp1_tp1_bf16_optadamw_lr0.0003_lwf0.05_flash//.cache/dolma/index-cache/f7d2e4b9462a6e17d2e80c2a4545516d_doc_idx.npy
  [2024-10-13 10:38:53.024649][DEBUG][gpt_dataset.py:950] -  > loading sample-idx mapping from checkpoints/ds_stage0_nl6_hs4096_mb12_seq4096_sp1_pp1_tp1_bf16_optadamw_lr0.0003_lwf0.05_flash//.cache/dolma/index-cache/f7d2e4b9462a6e17d2e80c2a4545516d_sample_idx.npy
  [2024-10-13 10:38:53.028050][DEBUG][gpt_dataset.py:953] -  > loading shuffle-idx mapping from checkpoints/ds_stage0_nl6_hs4096_mb12_seq4096_sp1_pp1_tp1_bf16_optadamw_lr0.0003_lwf0.05_flash//.cache/dolma/index-cache/f7d2e4b9462a6e17d2e80c2a4545516d_shuffle_idx.npy
  [2024-10-13 10:38:53.030382][DEBUG][gpt_dataset.py:956] -     loaded indexed file in 0.009 seconds
  [2024-10-13 10:38:53.031057][DEBUG][gpt_dataset.py:959] -     total number of samples: 584688
  [2024-10-13 10:38:53.031533][DEBUG][gpt_dataset.py:960] -     total number of epochs: 3
  [2024-10-13 10:38:53.032231][DEBUG][gpt_dataset.py:446] -  >> building dataset for /flare/Aurora_deployment/AuroraGPT/datasets/dolma/data_v1.7_Llama2Tokenizer/cc_en_middle-0323_text_document
  [2024-10-13 10:38:53.032845][DEBUG][gpt_dataset.py:604] -  > building dataset index ...
  [2024-10-13 10:38:53.035264][DEBUG][indexed_dataset.py:476] -     reading sizes...
  [2024-10-13 10:38:53.035931][DEBUG][indexed_dataset.py:480] -     reading pointers...
  [2024-10-13 10:38:53.036379][DEBUG][indexed_dataset.py:487] -     reading document index...
  [2024-10-13 10:38:53.036806][DEBUG][indexed_dataset.py:541] -     creating numpy buffer of mmap...
  [2024-10-13 10:38:53.037186][DEBUG][indexed_dataset.py:542] - /flare/Aurora_deployment/AuroraGPT/datasets/dolma/data_v1.7_Llama2Tokenizer/cc_en_middle-0323_text_document.bin
  [2024-10-13 10:38:53.037644][DEBUG][indexed_dataset.py:546] -     creating memory view of numpy buffer...
  [2024-10-13 10:38:53.038064][DEBUG][gpt_dataset.py:608] -  > finished creating indexed dataset in 0.004776 seconds
  [2024-10-13 10:38:53.038486][DEBUG][gpt_dataset.py:613] -     number of documents: 1795808
  [2024-10-13 10:38:53.038876][DEBUG][gpt_dataset.py:454] -  > dataset split:
  [2024-10-13 10:38:53.039214][DEBUG][gpt_dataset.py:457] -     train:
  [2024-10-13 10:38:53.039524][DEBUG][gpt_dataset.py:458] -      document indices in [0, 1795808) total of 1795808 documents
  [2024-10-13 10:38:53.039964][DEBUG][gpt_dataset.py:457] -     validation:
  [2024-10-13 10:38:53.040293][DEBUG][gpt_dataset.py:458] -      document indices in [1795808, 1795808) total of 0 documents
  [2024-10-13 10:38:53.040701][DEBUG][gpt_dataset.py:457] -     test:
  [2024-10-13 10:38:53.041008][DEBUG][gpt_dataset.py:458] -      document indices in [1795808, 1795808) total of 0 documents
  [2024-10-13 10:38:53.059401][DEBUG][gpt_dataset.py:947] -  > loading doc-idx mapping from checkpoints/ds_stage0_nl6_hs4096_mb12_seq4096_sp1_pp1_tp1_bf16_optadamw_lr0.0003_lwf0.05_flash//.cache/dolma/index-cache/2572e1fae8e82f973d4d4528bb1073d5_doc_idx.npy
  [2024-10-13 10:38:53.062711][DEBUG][gpt_dataset.py:950] -  > loading sample-idx mapping from checkpoints/ds_stage0_nl6_hs4096_mb12_seq4096_sp1_pp1_tp1_bf16_optadamw_lr0.0003_lwf0.05_flash//.cache/dolma/index-cache/2572e1fae8e82f973d4d4528bb1073d5_sample_idx.npy
  [2024-10-13 10:38:53.065822][DEBUG][gpt_dataset.py:953] -  > loading shuffle-idx mapping from checkpoints/ds_stage0_nl6_hs4096_mb12_seq4096_sp1_pp1_tp1_bf16_optadamw_lr0.0003_lwf0.05_flash//.cache/dolma/index-cache/2572e1fae8e82f973d4d4528bb1073d5_shuffle_idx.npy
  [2024-10-13 10:38:53.067502][DEBUG][gpt_dataset.py:956] -     loaded indexed file in 0.008 seconds
  [2024-10-13 10:38:53.068089][DEBUG][gpt_dataset.py:959] -     total number of samples: 339068
  [2024-10-13 10:38:53.068500][DEBUG][gpt_dataset.py:960] -     total number of epochs: 1
  
  
  # (...clipped...)

  [2024-10-13 10:38:53.069112][DEBUG][gpt_dataset.py:446] -  >> building dataset for /flare/Aurora_deployment/AuroraGPT/datasets/dolma/data_v1.7_Llama2Tokenizer/pes2o-0008_text_document
  [2024-10-13 10:38:53.069627][DEBUG][gpt_dataset.py:604] -  > building dataset index ...
  [2024-10-13 10:38:53.072254][DEBUG][indexed_dataset.py:476] -     reading sizes...
  [2024-10-13 10:38:53.072850][DEBUG][indexed_dataset.py:480] -     reading pointers...
  [2024-10-13 10:38:53.073281][DEBUG][indexed_dataset.py:487] -     reading document index...
  [2024-10-13 10:38:53.073709][DEBUG][indexed_dataset.py:541] -     creating numpy buffer of mmap...
  [2024-10-13 10:38:53.074143][DEBUG][indexed_dataset.py:542] - /flare/Aurora_deployment/AuroraGPT/datasets/dolma/data_v1.7_Llama2Tokenizer/pes2o-0008_text_document.bin
  [2024-10-13 10:38:53.074674][DEBUG][indexed_dataset.py:546] -     creating memory view of numpy buffer...
  [2024-10-13 10:38:53.075158][DEBUG][gpt_dataset.py:608] -  > finished creating indexed dataset in 0.005068 seconds
  [2024-10-13 10:38:53.075644][DEBUG][gpt_dataset.py:613] -     number of documents: 468277
  [2024-10-13 10:38:53.076103][DEBUG][gpt_dataset.py:454] -  > dataset split:
  [2024-10-13 10:38:53.076501][DEBUG][gpt_dataset.py:457] -     train:
  [2024-10-13 10:38:53.076879][DEBUG][gpt_dataset.py:458] -      document indices in [0, 468277) total of 468277 documents
  [2024-10-13 10:38:53.077385][DEBUG][gpt_dataset.py:457] -     validation:
  [2024-10-13 10:38:53.077797][DEBUG][gpt_dataset.py:458] -      document indices in [468277, 468277) total of 0 documents
  [2024-10-13 10:38:53.078301][DEBUG][gpt_dataset.py:457] -     test:
  [2024-10-13 10:38:53.078682][DEBUG][gpt_dataset.py:458] -      document indices in [468277, 468277) total of 0 documents
  [2024-10-13 10:38:53.085577][DEBUG][gpt_dataset.py:947] -  > loading doc-idx mapping from checkpoints/ds_stage0_nl6_hs4096_mb12_seq4096_sp1_pp1_tp1_bf16_optadamw_lr0.0003_lwf0.05_flash//.cache/dolma/index-cache/44232bbdda53b92a0c2f0a6e918b0b7c_doc_idx.npy
  [2024-10-13 10:38:53.089132][DEBUG][gpt_dataset.py:950] -  > loading sample-idx mapping from checkpoints/ds_stage0_nl6_hs4096_mb12_seq4096_sp1_pp1_tp1_bf16_optadamw_lr0.0003_lwf0.05_flash//.cache/dolma/index-cache/44232bbdda53b92a0c2f0a6e918b0b7c_sample_idx.npy
  [2024-10-13 10:38:53.092393][DEBUG][gpt_dataset.py:953] -  > loading shuffle-idx mapping from checkpoints/ds_stage0_nl6_hs4096_mb12_seq4096_sp1_pp1_tp1_bf16_optadamw_lr0.0003_lwf0.05_flash//.cache/dolma/index-cache/44232bbdda53b92a0c2f0a6e918b0b7c_shuffle_idx.npy
  [2024-10-13 10:38:53.095662][DEBUG][gpt_dataset.py:956] -     loaded indexed file in 0.010 seconds
  [2024-10-13 10:38:53.096285][DEBUG][gpt_dataset.py:959] -     total number of samples: 2441651
  [2024-10-13 10:38:53.096752][DEBUG][gpt_dataset.py:960] -     total number of epochs: 3

  [2024-10-13 10:39:13,696] [INFO] [logging.py:96:log_dist] [Rank 0] step=22, skipped=0, lr=[1.8402508875376674e-07, 1.8402508875376674e-07], mom=[(0.9, 0.95), (0.9, 0.95)]
  [2024-10-13 10:39:13,696] [INFO] [logging.py:96:log_dist] [Rank 0] time (ms) | fwd_microstep: 4631.17 | bwd_microstep: 15589.38 | bwd_inner_microstep: 14105.76 | bwd_allreduce_microstep: 1483.58 | step_microstep: 423.28
  [2024-10-13 10:39:13,696] [INFO] [logging.py:96:log_dist] [Rank 0] time (ms) | fwd: 4631.17 | bwd: 15589.38 | bwd_inner: 14105.76 | bwd_allreduce: 1483.59 | step: 423.28
  [2024-10-13 10:39:13.709465][INFO][training_log.py:661] -  iteration=      22/  105963 | consumed_samples=       14976 | consumed_tokens=    61341696 | elapsed_time_per_iteration_ms=20723.0 | learning_rate=1.84025e-07 | global_batch_size= 4608 | lm loss=11.192505 | grad_norm=6.578 | actual_seqlen= 4096 | number_of_skipped_iterations=  0 | number_of_nan_iterations=  0 | samples_per_second=222.362 | tokens_per_gpu_per_second_tgs=9487.424 | [LM]TFLOPs=79.45 | [DS]TFLOPs=102.11 |
  ```
  
  </details>



## `ALCF/helpers.sh`

- Use bash arrays instead of haphazardly concatenating strings in `ALCF/helpers.sh`
- Add ability to manually specify `${CKPT_DIR}` to specify checkpoint to try and load from

## Specifying `CKPT_DIR`

- We add new [functions](https://github.com/argonne-lcf/Megatron-DeepSpeed/blob/3e33a6a66d0dae2328e02cad1c760b862c0064dc/ALCF/helpers.sh#L883-L895) to [`ALCF/helpers.sh`](https://github.com/argonne-lcf/Megatron-DeepSpeed/blob/3e33a6a66d0dae2328e02cad1c760b862c0064dc/ALCF/helpers.sh) for determining the checkpoint directory when starting a new run.

  If specified at runtime, e.g.:

  ```bash
  CKPT_DIR=checkpoints/custom_checkpoint bash train_aGPT_7B.sh
  ```

  it will then:

  1. try and load checkpoint from
  2. save future checkpoints to
  
  If not specified, checkpoints will be saved to `checkpoints/$(get_output_prefix)` which will be a string that uniquely identifies each run, e.g.
  
  ```bash
  checkpoints/ws768_ds_stage1_nl32_hs4096_mb4_seq4096_gb3072_sp1_pp1_tp1_bf16_optadamw_lr0.00020_lwf0.05/
  ```

[^filtered]: Otherwise, it will be set to `INFO` by default,  
	and consequently, log messages emitted at level `DEBUG`, e.g.:  
	
	```bash
	[2024-10-13 10:38:52.996706][DEBUG][gpt_dataset.py:604] -  > building dataset index ...
	```
	
	will be filtered out.