### PR TITLE
fix: Call `set_ccl_vars_on_aurora` only if `WORLD_SIZE > 1`

### DIFF
--- a/ALCF/helpers.sh
+++ b/ALCF/helpers.sh
@@ -594,29 +594,6 @@ setParams() {
         else
             FLASH_ARG="--use-flash-attn-builder"
         fi
-        #### [sam: 08/17/2024] ##########################################
-        # Use best set of CCL env vars from Gordon Bell runs on Aurora
-        set_ccl_vars_on_aurora
-        #################################################################
-        #### [sam: 06/20/2024] ###############################################
-        # export CCL_PROCESS_LAUNCHER=pmix
-        # export CCL_ATL_TRANSPORT=mpi
-        # !XXX: USE KEY VALUE STORE FIX ON AURORA [2024-06-20]
-        # use_kvs_fix_on_aurora  # <-- why are these different from those in update_ccl_env_vars_aurora ??
-        # update_ccl_env_vars_aurora
-        ######################################################################
-        # if [[ -z "${USE_FLASH_ATTN:-}" ]]; then
-        #     # NOTE: if NO_FLASH_ATTN is NON-empty; then NO FLASH ATTN !!
-        #     export NO_FLASH_ATTN=1 # disabled on [2024-06-20] waiting on fix...
-        #     if [[ -n "${NO_FLASH_ATTN-}" ]]; then
-        #         echo "Not using flash-attn!!"
-        #     else
-        #         FLASH_ARG="--use-flash-attn-builder"
-        #     fi
-        # else
-        #     echo "Using flash-attn !!"
-        #     FLASH_ARG="--use-flash-attn-builder"
-        # fi
     # [Polaris]
     elif [[ "${mn}" == "polaris" || "${mn}" == "sirius" ]]; then
         # export LAUNCH_CMD="${LAUNCH_CMD:-deepspeed}"
@@ -679,6 +656,11 @@ setParams() {
     fi
     export NGPU_PER_HOST="${NGPU_PER_HOST}"
     export WORLD_SIZE="${WORLD_SIZE:-$((NHOSTS * NGPU_PER_HOST))}"
+    if [[ "${WORLD_SIZE}" -gt 1 && "${mn}" == "aurora" ]]; then
+        #### [sam: 08/17/2024] ##########################################
+        # Use best set of CCL env vars from Gordon Bell runs on Aurora
+        set_ccl_vars_on_aurora
+    fi
     # +---[Llama2 7B Config]--------------------------------------------------+
     # export MODEL_KEY="Llama-7B"
     export HEADS=${HEADS:-${NHEADS:-32}}             # NUMBER OF ATEN HEADS


### PR DESCRIPTION
This pull request includes changes to the `setParams()` function in the `ALCF/helpers.sh` file. The changes primarily involve the removal of outdated comments and code, and the addition of a conditional block to set CCL environment variables for Aurora when the world size is greater than 1.

Code cleanup and updates:

* Removed outdated comments and code related to setting CCL environment variables and using flash attention on Aurora.

Conditional environment variable setting:

* Added a conditional block to set the best set of CCL environment variables from Gordon Bell runs on Aurora when the world size is greater than 1.