### PR TITLE
fix: Fix imports in `pretrain_gpt_alcf.py`

### DIFF
--- a/ALCF/helpers.sh
+++ b/ALCF/helpers.sh
@@ -101,18 +101,18 @@ setup() {
     # Identify machine we're on
     get_machine || exit
     ##########################################################################
-    # ezpz_setup will:
-    # 1. Setup python
-    #     - load base conda
-    #     - (if necessary) create virtual environment on top of base conda
-    #     - activate virtual environment from ^
-    # 2. Install ezpz (if needed)
-    # 3. Parse PBS_* environment variables to determine:
-    #     - NHOSTS (by counting number of lines in $PBS_NODEFILE)
-    #     - NGPU_PER_HOST (by magic)
-    #     - NGPUS (= NHOSTS * NGPU_PER_HOST)
-    # 4. Use these (^) to build our launch command
-    ezpz_setup || exit
+    # # ezpz_setup will:
+    # # 1. Setup python
+    # #     - load base conda
+    # #     - (if necessary) create virtual environment on top of base conda
+    # #     - activate virtual environment from ^
+    # # 2. Install ezpz (if needed)
+    # # 3. Parse PBS_* environment variables to determine:
+    # #     - NHOSTS (by counting number of lines in $PBS_NODEFILE)
+    # #     - NGPU_PER_HOST (by magic)
+    # #     - NGPUS (= NHOSTS * NGPU_PER_HOST)
+    # # 4. Use these (^) to build our launch command
+    # ezpz_setup || exit
     ##########################################################################
     install_dependencies
     # Set command line arguments to pass to `"${EXEC}"`
@@ -126,7 +126,7 @@ setup() {
     set_args || exit
     # Ensure executable exists in expected path
     check_executable "${EXEC:-${WORKING_DIR}/pretrain_gpt_alcf.py}"
-    dfl="${DATA_FILE_LIST:-"${PBS_O_WORKDIR}/ALCF/data-lists/$(get_machine_name)/dolma.txt"}"
+    dfl="${DATA_FILE_LIST:-"${PBS_O_WORKDIR:-${HERE}}/ALCF/data-lists/$(get_machine_name)/dolma.txt"}"
     # Setup data + tokenizer via `DATA_FILE_LIST` and `TOKENIZER_TYPE`
     tok="${TOKENIZER_TYPE:-Llama2Tokenizer}"
     setup_tokenizer_and_data "${tok}" "${dfl}" || exit
@@ -796,30 +796,27 @@ make_ds_hostfile() {
 # 3. Call `_ezpz_install` (from `Megatron-DeepSpeed/ALCF/helpers.sh`):
 #    - Install ezpz from `"${WORKING_DIR}/depz/ezpz/"`
 ###########################################
-ezpz_setup() {
-    # setup_alcf "$@"
-    # file=$(mktemp)
-    # curl -Ls https://raw.githubusercontent.com/saforem2/ezpz/main/src/ezpz/bin/getjobenv > "${file}"
-    # shellcheck source=../deps/ezpz/src/ezpz/bin/utils.sh
-    ezdir="${WORKING_DIR}/deps/ezpz"
-    if [[ -d "${ezdir}" ]]; then
-        echo "Found ezpz in ${ezdir}"
-    else
-        mkdir -p "$(dirname "${ezdir}")"
-        git clone https://github.com/saforem2/ezpz "${ezdir}"
-    fi
-    # shellcheck source=../deps/ezpz/src/ezpz/bin/utils.sh
-    source "${ezdir}/src/ezpz/bin/utils.sh" || exit
-    ezpz_setup_python
-    ezpz_setup_job "$@"
-    ezpz_pip_loc=$(python3 -m pip list | grep ezpz | awk '{print $NF}')
-    if [[ -z "${ezpz_pip_loc:-}" ]]; then
-        printf "[ezpz_install] Installing ezpz from %s\n" "${ezdir}"
-        python3 -m pip install -e "${ezdir}" --require-virtualenv
-    else
-        printf "[ezpz_install] Found ezpz @ %s\n" "${ezpz_pip_loc}"
-    fi
-}
+# ezpz_setup() {
+#     source <()
+#     ezdir="${WORKING_DIR}/deps/ezpz"
+#     if [[ -d "${ezdir}" ]]; then
+#         echo "Found ezpz in ${ezdir}"
+#     else
+#         mkdir -p "$(dirname "${ezdir}")"
+#         git clone https://github.com/saforem2/ezpz "${ezdir}"
+#     fi
+#     # shellcheck source=../deps/ezpz/src/ezpz/bin/utils.sh
+#     source "${ezdir}/src/ezpz/bin/utils.sh" || exit
+#     ezpz_setup_python
+#     ezpz_setup_job "$@"
+#     ezpz_pip_loc=$(python3 -m pip list | grep ezpz | awk '{print $NF}')
+#     if [[ -z "${ezpz_pip_loc:-}" ]]; then
+#         printf "[ezpz_install] Installing ezpz from %s\n" "${ezdir}"
+#         python3 -m pip install -e "${ezdir}" --require-virtualenv
+#     else
+#         printf "[ezpz_install] Found ezpz @ %s\n" "${ezpz_pip_loc}"
+#     fi
+# }
 
 #######################################################################
 # ezpz_test: Run simple test to make sure all nodes in working order

--- a/train_alcf.sh
+++ b/train_alcf.sh
@@ -1,0 +1,44 @@
+#!/bin/bash --login
+#PBS -q lustre_scaling
+#PBS -A Aurora_Deployment
+#PBS -j oe
+
+#####################################
+# AuroraGPT-7B
+#
+# Main production script for training
+# AuroraGPT-7B @ ALCF
+#####################################
+train_aGPT() {
+
+    # 1. Navigate into `$PBS_O_WORKDIR`
+    # cd "${PBS_O_WORKDIR}" || exit
+    HERE=$(python3 -c 'import os; print(os.getcwd())') && export HERE
+    GIT_BRANCH=$(git branch --show-current) && export GIT_BRANCH
+
+    if [[ "${HERE}" != "${PBS_O_WORKDIR}" ]]; then
+        printf "[!! %s] WARNING: Current working directory (%s) does not match PBS_O_WORKDIR (%s)\n" "$(printRed "WARNING")" "${HERE}" "${PBS_O_WORKDIR}"
+        printf "[!! %s] This may cause issues with the job submission.\n" "$(printRed "WARNING")"
+        printf "Setting PBS_O_WORKDIR to %s and continuing...\n" "${HERE}"
+    fi
+
+    # 3. source `ezpz/bin/uitils.sh` and setup {job, python} environment:
+    source <(curl 'https://raw.githubusercontent.com/saforem2/ezpz/refs/heads/main/src/ezpz/bin/utils.sh') && ezpz_setup_env
+    python3 -m pip install "git+https://github.com/saforem2/ezpz"
+
+    # 2. source `ALCF/helpers.sh` for Megatron-DeepSpeed setup
+    source "${HERE}/ALCF/helpers.sh" || exit
+
+    # 3. call `setup` from `./ALCF/helpers.sh`
+    setup "$@" || exit
+    # export run_cmd="${run_cmd}"
+    echo "${run_cmd[@]}" | tee -a "${OUTPUT_LOG}"
+
+    # 4. Tell user where to find output
+    printf "[!! %s] View output at:\n %s\n" "$(printBlue "NOTE")" "$(printYellow "${OUTPUT_LOG}")" | tee -a "${OUTPUT_LOG}"
+
+    # 6. Evaluate ${run_cmd} and append outputs to ${OUTPUT_LOG}
+    eval "${run_cmd[*]}" |& tee -a "${OUTPUT_LOG}"
+}
+
+train_aGPT "$@"


### PR DESCRIPTION
This pull request updates the `pretrain_gpt_alcf.py` file to replace the `ez` library alias with `ezpz` throughout the codebase. The changes ensure consistent usage of the `ezpz` alias for all library functions and decorators.

### Library Alias Update:

* Replaced the `ez` alias with `ezpz` for all imports and usages of the library. This includes function calls like `setup_torch`, `get_rank`, `get_world_size`, `get_local_rank`, `get_torch_device_type`, and `setup_wandb`, as well as decorators like `timeitlogit`. [[1]](diffhunk://#diff-52cfc408bada5ae2b6539bda1621ccfd07255629316b7ac4ab08c40bf1dbdc15R4-R9) [[2]](diffhunk://#diff-52cfc408bada5ae2b6539bda1621ccfd07255629316b7ac4ab08c40bf1dbdc15L47-R62) [[3]](diffhunk://#diff-52cfc408bada5ae2b6539bda1621ccfd07255629316b7ac4ab08c40bf1dbdc15L70-R72) [[4]](diffhunk://#diff-52cfc408bada5ae2b6539bda1621ccfd07255629316b7ac4ab08c40bf1dbdc15L81-R86) [[5]](diffhunk://#diff-52cfc408bada5ae2b6539bda1621ccfd07255629316b7ac4ab08c40bf1dbdc15L456-R458)

### Code Cleanup:

* Removed the unused `ez` alias import to eliminate redundancy and ensure clarity in the code.