### PR TITLE
chore: Update ALCF/helpers.sh

### DIFF
--- a/ALCF/helpers.sh
+++ b/ALCF/helpers.sh
@@ -846,12 +846,12 @@ ezpz_test() {
 saveDSenv() {
     echo "Saving {PATH, LD_LIBRARY_PATH, htt{p,ps}_proxy, CFLAGS, PYTHONUSERBASE} to .deepspeed_env"
     {
-        echo "PATH=${PATH}"
-        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+        echo "PATH=${PATH:-}"
+        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
         echo "http_proxy=${http_proxy:-}"
         echo "https_proxy=${https_proxy:-}"
-        echo "CFLAGS=${CFLAGS}"
-        echo "PYTHONUSERBASE=$PYTHONUSERBASE"
+        echo "CFLAGS=${CFLAGS:-}"
+        echo "PYTHONUSERBASE=${PYTHONUSERBASE:-}"
     } >.deepspeed_env
 }
 

--- a/train_alcf.sh
+++ b/train_alcf.sh
@@ -16,14 +16,16 @@ train_aGPT() {
     HERE=$(python3 -c 'import os; print(os.getcwd())') && export HERE
     GIT_BRANCH=$(git branch --show-current) && export GIT_BRANCH
 
+    # 3. source `ezpz/bin/uitils.sh` and setup {job, python} environment:
+    source <(curl 'https://raw.githubusercontent.com/saforem2/ezpz/refs/heads/main/src/ezpz/bin/utils.sh') 
+
     if [[ "${HERE}" != "${PBS_O_WORKDIR}" ]]; then
         printf "[!! %s] WARNING: Current working directory (%s) does not match PBS_O_WORKDIR (%s)\n" "$(printRed "WARNING")" "${HERE}" "${PBS_O_WORKDIR}"
         printf "[!! %s] This may cause issues with the job submission.\n" "$(printRed "WARNING")"
         printf "Setting PBS_O_WORKDIR to %s and continuing...\n" "${HERE}"
     fi
 
-    # 3. source `ezpz/bin/uitils.sh` and setup {job, python} environment:
-    source <(curl 'https://raw.githubusercontent.com/saforem2/ezpz/refs/heads/main/src/ezpz/bin/utils.sh') && ezpz_setup_env
+    ezpz_setup_env
     python3 -m pip install "git+https://github.com/saforem2/ezpz"
 
     # 2. source `ALCF/helpers.sh` for Megatron-DeepSpeed setup

--- a/train_alcf.sh
+++ b/train_alcf.sh
@@ -19,7 +19,8 @@ train_aGPT() {
     # 3. source `ezpz/bin/uitils.sh` and setup {job, python} environment:
     source <(curl 'https://raw.githubusercontent.com/saforem2/ezpz/refs/heads/main/src/ezpz/bin/utils.sh') 
 
-    if [[ "${HERE}" != "${PBS_O_WORKDIR}" ]]; then
+    if [[ "${HERE}" != "${PBS_O_WORKDIR:-}" ]]; then
+        export PBS_O_WORKDIR="${HERE}"
         printf "[!! %s] WARNING: Current working directory (%s) does not match PBS_O_WORKDIR (%s)\n" "$(printRed "WARNING")" "${HERE}" "${PBS_O_WORKDIR}"
         printf "[!! %s] This may cause issues with the job submission.\n" "$(printRed "WARNING")"
         printf "Setting PBS_O_WORKDIR to %s and continuing...\n" "${HERE}"
@@ -40,7 +41,8 @@ train_aGPT() {
     printf "[!! %s] View output at:\n %s\n" "$(printBlue "NOTE")" "$(printYellow "${OUTPUT_LOG}")" | tee -a "${OUTPUT_LOG}"
 
     # 6. Evaluate ${run_cmd} and append outputs to ${OUTPUT_LOG}
-    eval "${run_cmd[*]}" |& tee -a "${OUTPUT_LOG}"
+    # eval "${run_cmd[*]}" |& tee -a "${OUTPUT_LOG}"
+    bash -c "${run_cmd[*]}" |& tee -a "${OUTPUT_LOG}"
 }
 
 train_aGPT "$@"

--- a/train_alcf.sh
+++ b/train_alcf.sh
@@ -26,8 +26,13 @@ train_aGPT() {
         printf "Setting PBS_O_WORKDIR to %s and continuing...\n" "${HERE}"
     fi
 
-    ezpz_setup_env
-    python3 -m pip install "git+https://github.com/saforem2/ezpz"
+    ezpz_setup_env || exit
+    if  command -v "ezpz-test"; then
+        printf "[!! %s] ezpz is already installed.\n" "$(printGreen "INFO")"
+    else
+        printf "[!! %s] ezpz is not installed. Installing...\n" "$(printRed "WARNING")"
+        python3 -m pip install "git+https://github.com/saforem2/ezpz"
+    fi
 
     # 2. source `ALCF/helpers.sh` for Megatron-DeepSpeed setup
     source "${HERE}/ALCF/helpers.sh" || exit
@@ -42,7 +47,13 @@ train_aGPT() {
 
     # 6. Evaluate ${run_cmd} and append outputs to ${OUTPUT_LOG}
     # eval "${run_cmd[*]}" |& tee -a "${OUTPUT_LOG}"
-    bash -c "${run_cmd[*]}" |& tee -a "${OUTPUT_LOG}"
+    if [[ "${DEBUG:-}" ]]; then
+        set -x
+        bash -c "${run_cmd[*]}" |& tee -a "${OUTPUT_LOG}"
+        set +x
+    else
+        bash -c "${run_cmd[*]}" |& tee -a "${OUTPUT_LOG}"
+    fi
 }
 
 train_aGPT "$@"

--- a/train_alcf.sh
+++ b/train_alcf.sh
@@ -27,12 +27,13 @@ train_aGPT() {
     fi
 
     ezpz_setup_env || exit
-    if  command -v "ezpz-test"; then
-        printf "[!! %s] ezpz is already installed.\n" "$(printGreen "INFO")"
-    else
-        printf "[!! %s] ezpz is not installed. Installing...\n" "$(printRed "WARNING")"
-        python3 -m pip install "git+https://github.com/saforem2/ezpz"
-    fi
+
+    # if  command -v "ezpz-test"; then
+    #     printf "[!! %s] ezpz is already installed.\n" "$(printGreen "INFO")"
+    # else
+    #     printf "[!! %s] ezpz is not installed. Installing...\n" "$(printRed "WARNING")"
+    #     python3 -m pip install "git+https://github.com/saforem2/ezpz"
+    # fi
 
     # 2. source `ALCF/helpers.sh` for Megatron-DeepSpeed setup
     source "${HERE}/ALCF/helpers.sh" || exit


### PR DESCRIPTION
## Copilot Summary

This pull request introduces several updates to the ALCF training scripts, focusing on refactoring the `ezpz_setup` functionality, improving environment setup processes, and adding a new main production script for training AuroraGPT-7B. The most notable changes include commenting out the `ezpz_setup` function in `helpers.sh`, enhancing the handling of working directories and environment variables, and introducing the `train_alcf.sh` script for streamlined training execution.

### Refactoring and commenting out `ezpz_setup`:

* The `ezpz_setup` function in `ALCF/helpers.sh` has been entirely commented out, effectively disabling it. This includes the logic for setting up Python, installing `ezpz`, and configuring the job environment.
* Calls to `ezpz_setup` have also been commented out or replaced with placeholder comments in the `setup()` function.

### Environment setup improvements:

* Updated the `DATA_FILE_LIST` fallback logic in `setup()` to ensure compatibility when `PBS_O_WORKDIR` is not set, defaulting to the current working directory (`HERE`).

### New training script:

* Added a new script, `train_alcf.sh`, which serves as the main production script for training AuroraGPT-7B at ALCF. It includes:
  - A check to ensure the current working directory matches `PBS_O_WORKDIR`, with a fallback to the current directory if they differ.
  - Integration of `ezpz` utilities via a remote source and setup of the job and Python environment.
  - Execution of the `setup()` function from `helpers.sh` and evaluation of the generated `run_cmd`.