### PR TITLE
Word Embedding init std adjustment

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1052,12 +1052,11 @@ def _add_initialization_args(parser):
     group.add_argument('--init-method-std', type=float, default=0.02,
                        help='Standard deviation of the zero mean normal '
                        'distribution used for weight initialization.')
-    group.add_argument('--scaled-word-embedding-init', action='store_true',
-                       help='Standard deviation of the zero mean normal '
-                       'distribution used for weight initialization.')
+    group.add_argument('--adjust-word-embedding-init', action='store_true',
+                       help='Use different initialization for word embedding weights')
     group.add_argument('--word-embedding-init-std', type=float, default=0.02,
                        help='Standard deviation of the zero mean normal '
-                       'distribution used for weight initialization.')
+                       'distribution used for word embedding weight initialization.')
     group.add_argument('--init-method-xavier-uniform', action='store_true',
                        help='Enable Xavier uniform parameter initialization')
 

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -1052,6 +1052,12 @@ def _add_initialization_args(parser):
     group.add_argument('--init-method-std', type=float, default=0.02,
                        help='Standard deviation of the zero mean normal '
                        'distribution used for weight initialization.')
+    group.add_argument('--scaled-word-embedding-init', action='store_true',
+                       help='Standard deviation of the zero mean normal '
+                       'distribution used for weight initialization.')
+    group.add_argument('--word-embedding-init-std', type=float, default=0.02,
+                       help='Standard deviation of the zero mean normal '
+                       'distribution used for weight initialization.')
     group.add_argument('--init-method-xavier-uniform', action='store_true',
                        help='Enable Xavier uniform parameter initialization')
 

--- a/megatron/core/models/gpt/gpt_embedding.py
+++ b/megatron/core/models/gpt/gpt_embedding.py
@@ -7,6 +7,7 @@ from megatron.core import tensor_parallel
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
 
+from megatron.core.utils import init_method_normal
 
 class GPTEmbedding(MegatronModule):
     """Language model embeddings.
@@ -30,7 +31,7 @@ class GPTEmbedding(MegatronModule):
         self.word_embeddings = tensor_parallel.VocabParallelEmbedding(
             num_embeddings=self.vocab_size,
             embedding_dim=self.config.hidden_size,
-            init_method=self.config.init_method,
+            init_method=self.config.world_embedding_init_method,
             config=self.config
         )
         # @jcasper are these keys needed?

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -214,10 +214,11 @@ class TransformerConfig(ModelParallelConfig):
         if self.init_method is None:
             self.init_method = init_method_normal(self.init_method_std)
 
-        if self.scaled_word_embedding_init:
-            self.world_embedding_init_method = init_method_normal(self.word_embedding_init_std)
-        else:
-            self.world_embedding_init_method = self.init_method
+        if self.world_embedding_init_method is None:
+            if self.scaled_word_embedding_init:
+                self.world_embedding_init_method = init_method_normal(self.word_embedding_init_std)
+            else:
+                self.world_embedding_init_method = self.init_method
         
         if self.output_layer_init_method is None:
             self.output_layer_init_method = scaled_init_method_normal(self.init_method_std, self.num_layers)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -58,6 +58,8 @@ class TransformerConfig(ModelParallelConfig):
                                              megatron.core.utils.scaled_init_method_normal(init_method_std)
                                              which is torch.nn.init.normal_ with mean=0.0 and
                                              std=init_method_std / math.sqrt(2.0 * num_layers).
+        
+        word_embedding_init_std (float): Standard deviation of the zero mean normal initialization for the word embeddings
 
         init_method_std (float): Standard deviation of the zero mean normal for the default
                                  initialization method, not used if init_method and
@@ -125,6 +127,9 @@ class TransformerConfig(ModelParallelConfig):
     init_method: Callable = None
     output_layer_init_method: Callable = None
     init_method_std: float = 0.02
+    scaled_word_embedding_init: bool = False
+    word_embedding_init_std: float = 0.02
+
 
     # mixed-precision
     apply_query_key_layer_scaling: bool = True
@@ -209,6 +214,11 @@ class TransformerConfig(ModelParallelConfig):
         if self.init_method is None:
             self.init_method = init_method_normal(self.init_method_std)
 
+        if self.scaled_word_embedding_init:
+            self.world_embedding_init_method = init_method_normal(self.word_embedding_init_std)
+        else:
+            self.world_embedding_init_method = self.init_method
+        
         if self.output_layer_init_method is None:
             self.output_layer_init_method = scaled_init_method_normal(self.init_method_std, self.num_layers)
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -127,7 +127,9 @@ class TransformerConfig(ModelParallelConfig):
     init_method: Callable = None
     output_layer_init_method: Callable = None
     init_method_std: float = 0.02
-    scaled_word_embedding_init: bool = False
+
+    adjust_word_embedding_init: bool = False
+    world_embedding_init_method: Callable = None
     word_embedding_init_std: float = 0.02
 
 
@@ -215,7 +217,7 @@ class TransformerConfig(ModelParallelConfig):
             self.init_method = init_method_normal(self.init_method_std)
 
         if self.world_embedding_init_method is None:
-            if self.scaled_word_embedding_init:
+            if self.adjust_word_embedding_init:
                 self.world_embedding_init_method = init_method_normal(self.word_embedding_init_std)
             else:
                 self.world_embedding_init_method = self.init_method


### PR DESCRIPTION
This pull request adds two new arguments to adjust word embedding initialization:
`--adjust-word-embedding-init` which enables reading a std value from a new different variable,
and 
`--word-embedding-init-std` which controls the init std if above flag is set.
I chose to have the enable flag so that we do not break any existing functionality in a case where a script is changing normal init std and thus the word embedding init std too. This way we retain that functionality as `--adjust-word-embedding-init` defaults to False if not set. 

This does not adjust positional embeddings and they are currently initialized with the default initialization method. 